### PR TITLE
Stabilize nested workflow graph export

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🔄 coze2dify
 
-**Coze → Dify Workflow Migration & Sync Engine**
+**Coze → Dify Workflow Migration Toolkit**
 
 [![CI](https://github.com/biaoma-ty/coze2dify/actions/workflows/ci.yml/badge.svg)](https://github.com/biaoma-ty/coze2dify/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-≥3.10-3776AB?logo=python&logoColor=white)](https://python.org)
@@ -21,9 +21,9 @@
 
 <br/><br/>
 
-*将 Coze 工作流自动转换为 Dify DSL 格式，支持可视化对比、增量同步与数据库直写。*
+*将 Coze 工作流转换为 Dify DSL / graph，当前重点是稳定迁移链路而不是完整平台产品。*
 
-*Automatically convert Coze workflows to Dify DSL format with visual diff, incremental sync, and direct DB writes.*
+*Convert Coze workflows into Dify DSL / graph. The current focus is migration correctness, not a fully finished platform product.*
 
 <br/>
 
@@ -37,16 +37,25 @@
 
 | Feature | Status | Description |
 |---------|--------|-------------|
-| 🔄 **Workflow Conversion** | ✅ Ready | Coze JSON/YAML → IR → Dify DSL YAML |
-| 📤 **Multi-Source Input** | ✅ Ready | File upload, Coze API, Database direct-read |
-| 📥 **Multi-Target Output** | ✅ Ready | DSL download, Dify DB direct-write |
-| 🗺️ **42-Node Mapping** | ✅ Ready | Complete node type mapping table |
-| 🔀 **Variable Transform** | ✅ Ready | Coze `BlockInputReference` → Dify `variable_selector` |
-| 📊 **Visual Diff** | ✅ Ready | Side-by-side React Flow comparison |
-| 🔍 **Platform Browse** | ✅ Ready | Connect Coze/Dify accounts, browse & select workflows |
-| 🛠️ **Dev Mode** | ✅ Ready | Auto-detect local docker deployments |
-| 🔁 **Incremental Sync** | ✅ Ready | Change detection, conflict resolution, scheduled sync |
-| 📋 **Conversion Report** | ✅ Ready | Mapping stats, warnings, unmappable nodes |
+| 🔄 **Workflow Conversion** | ✅ Verified | Coze JSON/YAML → IR → Dify graph / DSL |
+| 📂 **File Import + DSL Export** | ✅ Verified | Upload local workflow file and export generated DSL |
+| 🗺️ **Node Mapping** | 🟡 Partial | Main node types covered, but not every Coze construct is lossless |
+| 🔀 **Variable Transform** | 🟡 Partial | Common `BlockInputReference` cases work; edge cases still exist |
+| 📋 **Conversion Report** | ✅ Verified | Mapping stats, warnings, unmappable nodes |
+| 🗄️ **Direct Dify DB Write** | 🟡 Experimental | Backend writer works for local migration tests, UI/API flow is not fully wired |
+| 📊 **Visual Diff** | 🟡 Basic | Current UI shows report + mapping table, not a full graph diff |
+| 🔍 **Platform Browse** | 🚧 In Progress | Connection UI exists, workflow selection flow is not completed |
+| 🛠️ **Dev Mode** | 🟡 Experimental | Local service detection exists, but one-click workflow operations are limited |
+| 🔁 **Incremental Sync** | ❌ Planned | Sync endpoints and scheduling are mostly placeholders today |
+
+## 📌 Current Status
+
+- **Verified path**: file-based Coze workflow conversion into Dify graph / DSL.
+- **Verified in local testing**: migrated workflow can be written into a local Dify PostgreSQL instance and opened in Dify.
+- **Partially built**: platform browse, dev mode helpers, and direct-write UI.
+- **Not production-ready yet**: incremental sync, migration history persistence, and several API/database import flows.
+
+If you are evaluating the project, treat it as a working migration core with unfinished product surface area.
 
 ## 🏗️ Architecture
 
@@ -55,11 +64,13 @@
 │  Coze Source     │                              │  Dify Target     │
 │  ┌────────────┐  │                              │  ┌────────────┐  │
 │  │ JSON/YAML  │──┤                         ┌───→│  │ DSL YAML   │  │
-│  │ API Fetch  │──┤  CozeParser → IR → DifyGen   │  │ DB Write   │  │
-│  │ DB Reader  │──┤       │         │       └───→│  │ API Push   │  │
+│  │ API Fetch* │──┤  CozeParser → IR → DifyGen   │  │ DB Write*  │  │
+│  │ DB Reader* │──┤       │         │       └───→│  │ API Push*  │  │
 │  └────────────┘  │  Validator  Validator        │  └────────────┘  │
 └─────────────────┘                              └──────────────────┘
 ```
+
+`*` Experimental or partially wired.
 
 ### Why IR (Intermediate Representation)?
 
@@ -74,7 +85,7 @@
 
 - Python ≥ 3.10
 - Node.js ≥ 18
-- PostgreSQL 16 (optional, for sync/history)
+- PostgreSQL 16 (optional, for local Dify write testing)
 
 ### Option 1: Docker (Recommended)
 
@@ -110,6 +121,8 @@ npm run dev
 
 ### Platform Connection
 
+Some endpoints below exist in the API surface but are not all fully wired in the frontend flow yet.
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/api/v1/platform/coze/connect` | Test Coze PAT token |
@@ -125,16 +138,18 @@ npm run dev
 | `POST` | `/api/v1/coze/upload` | Upload Coze workflow file |
 | `POST` | `/api/v1/convert` | Execute conversion |
 | `GET`  | `/api/v1/convert/{id}/dsl` | Download Dify DSL |
-| `POST` | `/api/v1/convert/{id}/write-to-dify` | Direct-write to Dify DB |
+| `POST` | `/api/v1/convert/{id}/write-to-dify` | Reserved endpoint; public API flow not fully implemented yet |
 
 ### Sync
 
+The sync API surface is mostly scaffolded at the moment.
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/api/v1/sync/execute` | Trigger manual sync |
-| `GET`  | `/api/v1/sync/status` | Get sync status |
-| `GET`  | `/api/v1/sync/history` | Sync history list |
-| `POST` | `/api/v1/sync/diff` | Compare source/target diff |
+| `POST` | `/api/v1/sync/execute` | Placeholder endpoint |
+| `GET`  | `/api/v1/sync/status` | Basic status only |
+| `GET`  | `/api/v1/sync/history` | Placeholder response |
+| `POST` | `/api/v1/sync/diff` | Placeholder endpoint |
 
 ### Dev Mode
 
@@ -147,6 +162,8 @@ npm run dev
 > Full interactive docs available at `/docs` (Swagger UI) or `/redoc`.
 
 ## 🗺️ Node Mapping (42 types)
+
+The mapping table is the target design. Actual support quality varies by node type, and several mappings are still partial.
 
 | Coze Node | Dify Node | Level |
 |-----------|-----------|-------|
@@ -285,6 +302,8 @@ GitHub Actions pipeline runs on every push and PR:
 - **Docker**: Build validation for both services
 
 See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for details.
+
+Passing CI means the repository builds and lint/tests pass in CI. It does not mean every advertised UI/API workflow is complete.
 
 ## 📄 License
 

--- a/backend/core/dify/db_writer.py
+++ b/backend/core/dify/db_writer.py
@@ -69,6 +69,9 @@ class DifyDbWriter:
             # Create workflow
             graph_json = json.dumps(dsl.workflow.graph.model_dump())
             features_json = json.dumps(dsl.workflow.features or {})
+            environment_variables_json = self._serialize_named_variables(dsl.workflow.environment_variables)
+            conversation_variables_json = self._serialize_named_variables(dsl.workflow.conversation_variables)
+            rag_pipeline_variables_json = self._serialize_named_variables([])
             workflow_type = "workflow" if app_config.get("mode", "workflow") == "workflow" else "chat"
 
             conn.execute(
@@ -98,9 +101,9 @@ class DifyDbWriter:
                     "updated_by": account_id,
                     "created_at": now,
                     "updated_at": now,
-                    "environment_variables": json.dumps(dsl.workflow.environment_variables or []),
-                    "conversation_variables": json.dumps(dsl.workflow.conversation_variables or []),
-                    "rag_pipeline_variables": json.dumps([]),
+                    "environment_variables": environment_variables_json,
+                    "conversation_variables": conversation_variables_json,
+                    "rag_pipeline_variables": rag_pipeline_variables_json,
                     "marked_name": "",
                     "marked_comment": "",
                 },
@@ -111,6 +114,9 @@ class DifyDbWriter:
     def update_workflow(self, app_id: str, dsl: DifyDSL) -> None:
         graph_json = json.dumps(dsl.workflow.graph.model_dump())
         features_json = json.dumps(dsl.workflow.features or {})
+        environment_variables_json = self._serialize_named_variables(dsl.workflow.environment_variables)
+        conversation_variables_json = self._serialize_named_variables(dsl.workflow.conversation_variables)
+        rag_pipeline_variables_json = self._serialize_named_variables([])
         now = datetime.now(UTC).replace(tzinfo=None)
 
         with self.engine.begin() as conn:
@@ -120,6 +126,9 @@ class DifyDbWriter:
                     UPDATE workflows
                     SET graph = :graph,
                         features = :features,
+                        environment_variables = :environment_variables,
+                        conversation_variables = :conversation_variables,
+                        rag_pipeline_variables = :rag_pipeline_variables,
                         updated_by = :updated_by,
                         updated_at = :updated_at
                     WHERE app_id = :app_id
@@ -127,6 +136,9 @@ class DifyDbWriter:
                 {
                     "graph": graph_json,
                     "features": features_json,
+                    "environment_variables": environment_variables_json,
+                    "conversation_variables": conversation_variables_json,
+                    "rag_pipeline_variables": rag_pipeline_variables_json,
                     "updated_by": account_id,
                     "updated_at": now,
                     "app_id": app_id,
@@ -241,3 +253,17 @@ class DifyDbWriter:
             )
 
         return str(tenant_id), str(account_id)
+
+    @staticmethod
+    def _serialize_named_variables(variables: list[Any]) -> str:
+        if not variables:
+            return "{}"
+
+        payload: dict[str, Any] = {}
+        for index, variable in enumerate(variables):
+            if not isinstance(variable, dict):
+                continue
+            key = str(variable.get("name") or variable.get("variable") or variable.get("id") or f"var_{index}")
+            payload[key] = variable
+
+        return json.dumps(payload, ensure_ascii=False)

--- a/backend/core/dify/edge_builder.py
+++ b/backend/core/dify/edge_builder.py
@@ -26,6 +26,7 @@ _NODE_TYPE_TO_DIFY = {
     IRNodeType.VARIABLE_AGGREGATOR: "variable-aggregator",
     IRNodeType.VARIABLE_ASSIGNER: "assigner",
     IRNodeType.OUTPUT_EMITTER: "answer",
+    IRNodeType.TEXT_PROCESSOR: "template-transform",
     IRNodeType.INTENT_DETECTOR: "question-classifier",
     IRNodeType.QUESTION_ANSWER: "human-input",
     IRNodeType.KNOWLEDGE_WRITE: "knowledge-index",

--- a/backend/core/dify/generator.py
+++ b/backend/core/dify/generator.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import yaml
 
-from core.ir.models import IRNode, IRWorkflow
-from core.ir.types import IRNodeType
+from core.ir.models import IREdge, IRNode, IRVariable, IRWorkflow
+from core.ir.types import IRNodeType, IRVariableType
 
 from .edge_builder import EdgeBuilder
 from .models import DifyDSL, DifyEdge, DifyGraph, DifyNode, DifyNodeData, DifyWorkflow
@@ -46,6 +46,24 @@ _IR_TO_DIFY_TYPE: dict[IRNodeType, str] = {
     IRNodeType.KNOWLEDGE_DELETE: "http-request",
 }
 
+_IR_TO_INPUT_TYPE: dict[IRVariableType, str] = {
+    IRVariableType.STRING: "text-input",
+    IRVariableType.INTEGER: "number",
+    IRVariableType.FLOAT: "number",
+    IRVariableType.NUMBER: "number",
+    IRVariableType.BOOLEAN: "checkbox",
+    IRVariableType.OBJECT: "json_object",
+    IRVariableType.ARRAY: "json",
+    IRVariableType.ARRAY_STRING: "json",
+    IRVariableType.ARRAY_NUMBER: "json",
+    IRVariableType.ARRAY_OBJECT: "json",
+    IRVariableType.FILE: "file",
+    IRVariableType.ANY: "text-input",
+}
+
+_ITERATION_NODE_Z_INDEX = 1
+_COMPOSITE_CHILD_Z_INDEX = 1002
+
 # Force import node generators so they register themselves
 from core.dify.node_generators import code as _code_generator  # noqa: F401, E402
 from core.dify.node_generators import http_request as _http_request_generator  # noqa: F401, E402
@@ -64,14 +82,13 @@ class DifyGenerator:
         node_map = {n.id: n for n in flat_nodes}
         edge_builder = EdgeBuilder(node_map)
 
-        dify_nodes = [self._generate_node(ir_node) for ir_node in flat_nodes if ir_node.node_type != IRNodeType.COMMENT]
-
-        all_edges: list[DifyEdge] = []
+        dify_nodes: list[DifyNode] = []
         for ir_node in ir_workflow.nodes:
-            all_edges.extend(self._build_child_edges(ir_node, edge_builder))
+            dify_nodes.extend(self._generate_nodes(ir_node))
 
-        # Build top-level edges
-        all_edges.extend(edge_builder.build_edges(ir_workflow.edges))
+        all_edges = edge_builder.build_edges(ir_workflow.edges)
+        for ir_node in ir_workflow.nodes:
+            all_edges.extend(self._build_composite_edges(ir_node, edge_builder))
 
         graph = DifyGraph(nodes=dify_nodes, edges=all_edges)
         workflow = DifyWorkflow(graph=graph)
@@ -87,22 +104,56 @@ class DifyGenerator:
             workflow=workflow,
         )
 
-    def _generate_node(self, ir_node: IRNode) -> DifyNode:
-        dify_type = _IR_TO_DIFY_TYPE.get(ir_node.node_type, "code")
+    def _generate_nodes(self, ir_node: IRNode, parent: IRNode | None = None) -> list[DifyNode]:
+        nodes: list[DifyNode] = []
+        if ir_node.node_type != IRNodeType.COMMENT:
+            nodes.append(self._generate_node(ir_node, parent))
 
-        node_data = DifyNodeData(type=dify_type, title=ir_node.title, desc=ir_node.description)
+        if self._is_composite_node(ir_node):
+            nodes.append(self._generate_composite_start_node(ir_node))
+
+        for child in ir_node.children:
+            next_parent = ir_node if self._is_composite_node(ir_node) else parent
+            nodes.extend(self._generate_nodes(child, next_parent))
+
+        return nodes
+
+    def _generate_node(self, ir_node: IRNode, parent: IRNode | None = None) -> DifyNode:
+        dify_type = _IR_TO_DIFY_TYPE.get(ir_node.node_type, "code")
+        node_payload = self._default_node_payload(ir_node)
 
         # Delegate to type-specific generator
         generator = get_node_generator(ir_node.node_type)
         if generator:
-            extra = generator.generate(ir_node, self.var_transformer)
-            node_data.extra = extra
+            node_payload.update(generator.generate(ir_node, self.var_transformer))
 
-        return DifyNode(
-            id=ir_node.id,
-            data=node_data,
-            position={"x": ir_node.position.x, "y": ir_node.position.y},
+        node_kwargs: dict[str, Any] = {
+            "id": ir_node.id,
+            "position": {"x": ir_node.position.x, "y": ir_node.position.y},
+        }
+
+        if self._is_iteration_node(ir_node):
+            node_kwargs["width"] = 388
+            node_kwargs["height"] = 178
+            node_kwargs["zIndex"] = _ITERATION_NODE_Z_INDEX
+        elif self._is_loop_node(ir_node):
+            node_kwargs["width"] = 884
+            node_kwargs["height"] = 225
+            node_kwargs["zIndex"] = _ITERATION_NODE_Z_INDEX
+
+        if parent:
+            node_kwargs["parentId"] = parent.id
+            node_kwargs["zIndex"] = _COMPOSITE_CHILD_Z_INDEX
+            self._annotate_child_payload(node_payload, parent)
+
+        node_data = DifyNodeData(
+            type=dify_type,
+            title=ir_node.title,
+            desc=ir_node.description,
+            **node_payload,
         )
+
+        return DifyNode(data=node_data, **node_kwargs)
 
     def to_yaml(self, dsl: DifyDSL) -> str:
         return yaml.dump(
@@ -120,27 +171,297 @@ class DifyGenerator:
                 flattened.extend(self._flatten_nodes(node.children))
         return flattened
 
-    def _build_child_edges(
-        self,
-        ir_node: IRNode,
-        edge_builder: EdgeBuilder,
-        in_loop: bool = False,
-        in_iteration: bool = False,
-    ) -> list[DifyEdge]:
-        node_in_loop = in_loop or ir_node.node_type in (IRNodeType.LOOP_COUNTED, IRNodeType.LOOP_INFINITE)
-        node_in_iteration = in_iteration or ir_node.node_type in (IRNodeType.LOOP_ARRAY, IRNodeType.BATCH)
-
+    def _build_composite_edges(self, ir_node: IRNode, edge_builder: EdgeBuilder) -> list[DifyEdge]:
         edges: list[DifyEdge] = []
-        if ir_node.child_edges:
-            edges.extend(
-                edge_builder.build_edges(
-                    ir_node.child_edges,
-                    in_loop=node_in_loop,
-                    in_iteration=node_in_iteration,
-                )
-            )
+        if self._is_composite_node(ir_node):
+            for child_edge in ir_node.child_edges:
+                mapped_edges = self._map_composite_edge(ir_node, child_edge, edge_builder)
+                edges.extend(mapped_edges)
 
         for child in ir_node.children:
-            edges.extend(self._build_child_edges(child, edge_builder, node_in_loop, node_in_iteration))
+            edges.extend(self._build_composite_edges(child, edge_builder))
 
         return edges
+
+    def _default_node_payload(self, ir_node: IRNode) -> dict[str, Any]:
+        match ir_node.node_type:
+            case IRNodeType.START:
+                return {"variables": [self._to_start_variable(var) for var in ir_node.inputs]}
+            case IRNodeType.END:
+                return {"outputs": self._to_end_outputs(ir_node.inputs)}
+            case IRNodeType.CODE:
+                return {"code": "", "code_language": "python3", "variables": [], "outputs": {}}
+            case IRNodeType.HTTP_REQUEST:
+                return {
+                    "variables": [],
+                    "method": "get",
+                    "url": "",
+                    "headers": "",
+                    "params": "",
+                    "body": {"type": "none", "data": []},
+                    "authorization": {"type": "no-auth", "config": None},
+                    "timeout": {
+                        "max_connect_timeout": 0,
+                        "max_read_timeout": 0,
+                        "max_write_timeout": 0,
+                    },
+                    "ssl_verify": True,
+                    "retry_config": {
+                        "retry_enabled": True,
+                        "max_retries": 3,
+                        "retry_interval": 100,
+                    },
+                }
+            case IRNodeType.CONDITION:
+                return {
+                    "cases": [{"case_id": "true", "logical_operator": "and", "conditions": []}],
+                    "isInIteration": False,
+                    "isInLoop": False,
+                }
+            case IRNodeType.LOOP_COUNTED | IRNodeType.LOOP_INFINITE:
+                return {
+                    "start_node_id": self._get_composite_start_node_id(ir_node),
+                    "logical_operator": "and",
+                    "break_conditions": [],
+                    "loop_count": int(ir_node.config.get("loop_count") or ir_node.config.get("max_iterations") or 10),
+                    "error_handle_mode": "terminated",
+                    "loop_variables": [],
+                }
+            case IRNodeType.LOOP_ARRAY | IRNodeType.BATCH:
+                iterator_selector = ir_node.config.get("iterator_selector", [])
+                if not isinstance(iterator_selector, list):
+                    iterator_selector = []
+                return {
+                    "start_node_id": self._get_composite_start_node_id(ir_node),
+                    "iterator_selector": iterator_selector,
+                    "iterator_input_type": "array",
+                    "output_selector": self._get_composite_output_selector(ir_node),
+                    "output_type": self._get_iteration_output_type(ir_node),
+                    "is_parallel": ir_node.node_type == IRNodeType.BATCH,
+                    "parallel_nums": 10,
+                    "error_handle_mode": "terminated",
+                    "flatten_output": True,
+                    "_isShowTips": False,
+                }
+            case IRNodeType.TEXT_PROCESSOR:
+                return {
+                    "variables": self._to_value_variables(ir_node.inputs),
+                    "template": ir_node.config.get("template", ""),
+                }
+            case IRNodeType.OUTPUT_EMITTER:
+                return {
+                    "variables": self._to_value_variables(ir_node.inputs),
+                    "answer": self._build_text_template(ir_node.inputs),
+                }
+            case _:
+                return {}
+
+    def _to_start_variable(self, var: IRVariable) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "type": _IR_TO_INPUT_TYPE.get(var.var_type, "text-input"),
+            "label": var.name,
+            "variable": var.name,
+            "required": var.required,
+        }
+        if var.description:
+            item["hint"] = var.description
+        if var.default_value is not None:
+            item["default"] = var.default_value
+        return item
+
+    def _to_value_variables(self, variables: list[IRVariable]) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for var in variables:
+            entry = {"variable": var.name, "value_selector": []}
+            if var.ref:
+                entry["value_selector"] = self.var_transformer.to_selector(var.ref)
+            result.append(entry)
+        return result
+
+    def _to_end_outputs(self, variables: list[IRVariable]) -> list[dict[str, Any]]:
+        outputs: list[dict[str, Any]] = []
+        for var in variables:
+            entry: dict[str, Any] = {"variable": var.name, "value_selector": []}
+            if var.ref:
+                entry["value_selector"] = self.var_transformer.to_selector(var.ref)
+            outputs.append(entry)
+        return outputs
+
+    def _build_text_template(self, variables: list[IRVariable]) -> str:
+        fragments: list[str] = []
+        for var in variables:
+            if var.literal_value is not None:
+                fragments.append(str(var.literal_value))
+            elif var.ref:
+                fragments.append(self.var_transformer.to_template(var.ref))
+        return "\n".join(fragment for fragment in fragments if fragment)
+
+    @staticmethod
+    def _get_composite_start_node_id(ir_node: IRNode) -> str:
+        return f"{ir_node.id}start"
+
+    def _generate_composite_start_node(self, ir_node: IRNode) -> DifyNode:
+        is_iteration = self._is_iteration_node(ir_node)
+        return DifyNode(
+            id=self._get_composite_start_node_id(ir_node),
+            type="custom-iteration-start" if is_iteration else "custom-loop-start",
+            data=DifyNodeData(
+                type="iteration-start" if is_iteration else "loop-start",
+                title="",
+                desc="",
+                isInIteration=is_iteration,
+                isInLoop=not is_iteration,
+            ),
+            parentId=ir_node.id,
+            position={"x": 24 if is_iteration else 60, "y": 68 if is_iteration else 88.5},
+            width=44,
+            height=48,
+            zIndex=_COMPOSITE_CHILD_Z_INDEX,
+            draggable=False,
+            selectable=False,
+        )
+
+    def _map_composite_edge(self, parent: IRNode, edge: IREdge, edge_builder: EdgeBuilder) -> list[DifyEdge]:
+        if edge.source_node_id == parent.id:
+            target_node = self._find_node(parent, edge.target_node_id)
+            return [
+                self._make_special_edge(
+                    source_id=self._get_composite_start_node_id(parent),
+                    target_id=edge.target_node_id,
+                    source_type="iteration-start" if self._is_iteration_node(parent) else "loop-start",
+                    target_type=_IR_TO_DIFY_TYPE.get(target_node.node_type, "custom") if target_node else "custom",
+                    parent=parent,
+                )
+            ]
+
+        if edge.target_node_id == parent.id:
+            return []
+
+        mapped_edges = edge_builder.build_edges(
+            [edge],
+            in_loop=self._is_loop_node(parent),
+            in_iteration=self._is_iteration_node(parent),
+        )
+        for mapped_edge in mapped_edges:
+            self._annotate_edge_for_parent(mapped_edge, parent)
+        return mapped_edges
+
+    def _make_special_edge(
+        self,
+        *,
+        source_id: str,
+        target_id: str,
+        source_type: str,
+        target_type: str,
+        parent: IRNode,
+        source_handle: str = "source",
+        target_handle: str = "target",
+    ) -> DifyEdge:
+        data: dict[str, Any] = {
+            "sourceType": source_type,
+            "targetType": target_type,
+            "isInIteration": self._is_iteration_node(parent),
+            "isInLoop": self._is_loop_node(parent),
+        }
+        if self._is_iteration_node(parent):
+            data["iteration_id"] = parent.id
+        if self._is_loop_node(parent):
+            data["loop_id"] = parent.id
+
+        return DifyEdge(
+            id=f"{source_id}-{source_handle}-{target_id}-{target_handle}",
+            source=source_id,
+            sourceHandle=source_handle,
+            target=target_id,
+            targetHandle=target_handle,
+            data=data,
+            zIndex=_COMPOSITE_CHILD_Z_INDEX,
+        )
+
+    def _annotate_child_payload(self, node_payload: dict[str, Any], parent: IRNode) -> None:
+        is_iteration = self._is_iteration_node(parent)
+        node_payload["isInIteration"] = is_iteration
+        node_payload["isInLoop"] = not is_iteration
+        if is_iteration:
+            node_payload["iteration_id"] = parent.id
+        else:
+            node_payload["loop_id"] = parent.id
+
+    def _annotate_edge_for_parent(self, edge: DifyEdge, parent: IRNode) -> None:
+        edge.zIndex = _COMPOSITE_CHILD_Z_INDEX
+        edge.data["isInIteration"] = self._is_iteration_node(parent)
+        edge.data["isInLoop"] = self._is_loop_node(parent)
+        if self._is_iteration_node(parent):
+            edge.data["iteration_id"] = parent.id
+        if self._is_loop_node(parent):
+            edge.data["loop_id"] = parent.id
+
+    def _get_composite_output_selector(self, ir_node: IRNode) -> list[str]:
+        for edge in reversed(ir_node.child_edges):
+            if edge.target_node_id != ir_node.id:
+                continue
+            source_node = self._find_node(ir_node, edge.source_node_id)
+            if source_node and source_node.outputs:
+                return [source_node.id, source_node.outputs[0].name]
+        return []
+
+    def _get_iteration_output_type(self, ir_node: IRNode) -> str:
+        selector = self._get_composite_output_selector(ir_node)
+        if len(selector) != 2:
+            return "array"
+        source_node = self._find_node(ir_node, selector[0])
+        if not source_node:
+            return "array"
+        for output in source_node.outputs:
+            if output.name == selector[1]:
+                return self._wrap_iteration_output_type(output.var_type)
+        return "array"
+
+    def _find_node(self, root: IRNode, node_id: str) -> IRNode | None:
+        for child in root.children:
+            if child.id == node_id:
+                return child
+            found = self._find_node(child, node_id)
+            if found:
+                return found
+        return None
+
+    def _wrap_iteration_output_type(self, var_type: IRVariableType) -> str:
+        match var_type:
+            case IRVariableType.STRING:
+                return "array[string]"
+            case IRVariableType.INTEGER | IRVariableType.FLOAT | IRVariableType.NUMBER:
+                return "array[number]"
+            case IRVariableType.BOOLEAN:
+                return "array[boolean]"
+            case IRVariableType.OBJECT:
+                return "array[object]"
+            case IRVariableType.FILE:
+                return "array[file]"
+            case IRVariableType.ARRAY:
+                return "array"
+            case IRVariableType.ARRAY_STRING:
+                return "array[string]"
+            case IRVariableType.ARRAY_NUMBER:
+                return "array[number]"
+            case IRVariableType.ARRAY_OBJECT:
+                return "array[object]"
+            case _:
+                return "array"
+
+    @staticmethod
+    def _is_composite_node(ir_node: IRNode) -> bool:
+        return ir_node.node_type in (
+            IRNodeType.LOOP_ARRAY,
+            IRNodeType.BATCH,
+            IRNodeType.LOOP_COUNTED,
+            IRNodeType.LOOP_INFINITE,
+        )
+
+    @staticmethod
+    def _is_iteration_node(ir_node: IRNode) -> bool:
+        return ir_node.node_type in (IRNodeType.LOOP_ARRAY, IRNodeType.BATCH)
+
+    @staticmethod
+    def _is_loop_node(ir_node: IRNode) -> bool:
+        return ir_node.node_type in (IRNodeType.LOOP_COUNTED, IRNodeType.LOOP_INFINITE)

--- a/backend/core/dify/models.py
+++ b/backend/core/dify/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DifyEdge(BaseModel):
@@ -17,11 +17,12 @@ class DifyEdge(BaseModel):
 
 
 class DifyNodeData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     type: str
     title: str = ""
     desc: str = ""
     selected: bool = False
-    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class DifyNode(BaseModel):
@@ -33,6 +34,10 @@ class DifyNode(BaseModel):
     type: str = "custom"
     sourcePosition: str = "right"
     targetPosition: str = "left"
+    parentId: str | None = None
+    zIndex: int | None = None
+    draggable: bool | None = None
+    selectable: bool | None = None
 
 
 class DifyGraph(BaseModel):

--- a/backend/core/dify/node_generators/code.py
+++ b/backend/core/dify/node_generators/code.py
@@ -11,9 +11,9 @@ _TYPE_MAP = {
     IRVariableType.INTEGER: "number",
     IRVariableType.FLOAT: "number",
     IRVariableType.NUMBER: "number",
-    IRVariableType.BOOLEAN: "string",
+    IRVariableType.BOOLEAN: "boolean",
     IRVariableType.OBJECT: "object",
-    IRVariableType.ARRAY: "array[string]",
+    IRVariableType.ARRAY: "array[any]",
     IRVariableType.ANY: "string",
 }
 

--- a/backend/core/dify/node_generators/http_request.py
+++ b/backend/core/dify/node_generators/http_request.py
@@ -10,12 +10,38 @@ from . import register_generator
 class HTTPRequestNodeGenerator:
     def generate(self, ir_node: Any, var_transformer: Any) -> dict[str, Any]:
         config = ir_node.config
+        variables: list[dict[str, Any]] = []
+        for inp in ir_node.inputs:
+            var_entry = {"variable": inp.name, "value_selector": []}
+            if inp.ref:
+                var_entry["value_selector"] = var_transformer.to_selector(inp.ref)
+            variables.append(var_entry)
+
         return {
-            "method": config.get("method", "GET"),
+            "variables": variables,
+            "method": str(config.get("method", "get")).lower(),
             "url": config.get("url", ""),
             "headers": config.get("headers", ""),
+            "params": config.get("params", ""),
             "body": {"type": config.get("body_type", "none"), "data": config.get("body", "")},
             "authorization": config.get("authorization", {"type": "no-auth"}),
+            "timeout": config.get(
+                "timeout",
+                {
+                    "max_connect_timeout": 0,
+                    "max_read_timeout": 0,
+                    "max_write_timeout": 0,
+                },
+            ),
+            "ssl_verify": config.get("ssl_verify", True),
+            "retry_config": config.get(
+                "retry_config",
+                {
+                    "retry_enabled": True,
+                    "max_retries": 3,
+                    "retry_interval": 100,
+                },
+            ),
         }
 
 

--- a/backend/core/dify/node_generators/if_else.py
+++ b/backend/core/dify/node_generators/if_else.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.ir.types import IRConditionOperator, IRNodeType
+from core.ir.types import IRConditionOperator, IRNodeType, IRVariableType
 
 from . import register_generator
 
@@ -10,19 +10,34 @@ _OPERATOR_MAP = {
     IRConditionOperator.EQUAL: "is",
     IRConditionOperator.NOT_EQUAL: "is not",
     IRConditionOperator.GREATER_THAN: ">",
-    IRConditionOperator.GREATER_THAN_EQUAL: ">=",
+    IRConditionOperator.GREATER_THAN_EQUAL: "≥",
     IRConditionOperator.LESS_THAN: "<",
-    IRConditionOperator.LESS_THAN_EQUAL: "<=",
+    IRConditionOperator.LESS_THAN_EQUAL: "≤",
     IRConditionOperator.CONTAINS: "contains",
     IRConditionOperator.NOT_CONTAINS: "not contains",
     IRConditionOperator.EMPTY: "empty",
     IRConditionOperator.NOT_EMPTY: "not empty",
     IRConditionOperator.IS_TRUE: "is",
-    IRConditionOperator.IS_FALSE: "is not",
+    IRConditionOperator.IS_FALSE: "is",
     IRConditionOperator.START_WITH: "start with",
     IRConditionOperator.END_WITH: "end with",
     IRConditionOperator.IN: "in",
     IRConditionOperator.NOT_IN: "not in",
+}
+
+_VAR_TYPE_MAP = {
+    IRVariableType.STRING: "string",
+    IRVariableType.INTEGER: "integer",
+    IRVariableType.FLOAT: "number",
+    IRVariableType.NUMBER: "number",
+    IRVariableType.BOOLEAN: "boolean",
+    IRVariableType.OBJECT: "object",
+    IRVariableType.ARRAY: "array",
+    IRVariableType.ARRAY_STRING: "array[string]",
+    IRVariableType.ARRAY_NUMBER: "array[number]",
+    IRVariableType.ARRAY_OBJECT: "array[object]",
+    IRVariableType.FILE: "file",
+    IRVariableType.ANY: "any",
 }
 
 
@@ -30,27 +45,46 @@ class IfElseNodeGenerator:
     def generate(self, ir_node: Any, var_transformer: Any) -> dict[str, Any]:
         cases: list[dict[str, Any]] = []
 
-        for branch in ir_node.branches:
+        for branch_index, branch in enumerate(ir_node.branches):
             conditions: list[dict[str, Any]] = []
 
-            for cond in branch.conditions:
+            for condition_index, cond in enumerate(branch.conditions):
+                var_type = "string"
+                if cond.right:
+                    var_type = _VAR_TYPE_MAP.get(cond.right.var_type, "any")
+
                 dify_cond: dict[str, Any] = {
+                    "id": f"{branch.branch_id}_{condition_index}",
+                    "varType": var_type,
                     "comparison_operator": _OPERATOR_MAP.get(cond.operator, "is"),
                     "variable_selector": var_transformer.to_selector(cond.left),
                 }
-                if cond.right and cond.right.literal_value is not None:
+                if cond.operator == IRConditionOperator.IS_TRUE:
+                    dify_cond["varType"] = "boolean"
+                    dify_cond["value"] = True
+                elif cond.operator == IRConditionOperator.IS_FALSE:
+                    dify_cond["varType"] = "boolean"
+                    dify_cond["value"] = False
+                elif cond.right and cond.right.literal_value is not None:
                     dify_cond["value"] = cond.right.literal_value
                 conditions.append(dify_cond)
 
             cases.append(
                 {
-                    "case_id": branch.branch_id,
+                    "case_id": branch.branch_id or ("true" if branch_index == 0 else f"true_{branch_index}"),
                     "logical_operator": branch.logic,
                     "conditions": conditions,
                 }
             )
 
-        return {"cases": cases}
+        if not cases:
+            cases = [{"case_id": "true", "logical_operator": "and", "conditions": []}]
+
+        return {
+            "cases": cases,
+            "isInIteration": False,
+            "isInLoop": False,
+        }
 
 
 register_generator(IRNodeType.CONDITION, IfElseNodeGenerator())

--- a/backend/core/engine/converter.py
+++ b/backend/core/engine/converter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from core.coze.parser import CozeParser
 from core.dify.generator import DifyGenerator
 from core.dify.models import DifyDSL
-from core.ir.models import ConversionReport, IRWorkflow, NodeConversionResult
+from core.ir.models import ConversionReport, IRNode, IRWorkflow, NodeConversionResult
 from core.mapper.node_mapper import NodeMapper
 
 
@@ -32,7 +32,8 @@ class ConversionEngine:
         results: list[NodeConversionResult] = []
         mapped = partial = unmappable = skipped = 0
 
-        for node in ir_workflow.nodes:
+        all_nodes = self._iter_nodes(ir_workflow.nodes)
+        for node in all_nodes:
             rule = self.node_mapper.get_rule(node.node_type)
             result = NodeConversionResult(
                 source_node_id=node.id,
@@ -56,10 +57,18 @@ class ConversionEngine:
 
         return ConversionReport(
             workflow_name=ir_workflow.name,
-            total_nodes=len(ir_workflow.nodes),
+            total_nodes=len(all_nodes),
             mapped_count=mapped,
             partial_count=partial,
             unmappable_count=unmappable,
             skipped_count=skipped,
             node_results=results,
         )
+
+    def _iter_nodes(self, nodes: list[IRNode]) -> list[IRNode]:
+        flattened: list[IRNode] = []
+        for node in nodes:
+            flattened.append(node)
+            if node.children:
+                flattened.extend(self._iter_nodes(node.children))
+        return flattened

--- a/backend/tests/test_composite_graph.py
+++ b/backend/tests/test_composite_graph.py
@@ -1,0 +1,105 @@
+from core.dify.generator import DifyGenerator
+from core.engine.converter import ConversionEngine
+from core.ir.models import IRBranch, IREdge, IRNode, IRPosition, IRVariable, IRWorkflow
+from core.ir.types import IRNodeType, IRVariableType
+
+
+def _node(
+    node_id: str,
+    node_type: IRNodeType,
+    *,
+    position: tuple[float, float] = (0, 0),
+    config: dict | None = None,
+    children: list[IRNode] | None = None,
+    child_edges: list[IREdge] | None = None,
+    outputs: list[IRVariable] | None = None,
+    branches: list[IRBranch] | None = None,
+) -> IRNode:
+    return IRNode(
+        id=node_id,
+        node_type=node_type,
+        title=node_type.value,
+        position=IRPosition(x=position[0], y=position[1]),
+        config=config or {},
+        children=children or [],
+        child_edges=child_edges or [],
+        outputs=outputs or [],
+        branches=branches or [],
+        source_type_name=node_type.value,
+    )
+
+
+def test_conversion_report_counts_child_nodes() -> None:
+    child = _node(
+        "child-code",
+        IRNodeType.CODE,
+        outputs=[IRVariable(name="result", var_type=IRVariableType.STRING)],
+    )
+    iteration = _node(
+        "iteration",
+        IRNodeType.LOOP_ARRAY,
+        config={"iterator_selector": ["start", "items"]},
+        children=[child],
+    )
+    workflow = IRWorkflow(
+        nodes=[
+            _node("start", IRNodeType.START),
+            iteration,
+            _node("end", IRNodeType.END),
+        ]
+    )
+
+    _, report = ConversionEngine().convert_from_ir(workflow)
+
+    assert report.total_nodes == 4
+    assert {result.source_node_id for result in report.node_results} == {"start", "iteration", "child-code", "end"}
+
+
+def test_iteration_children_are_nested_without_return_edges() -> None:
+    selector = _node(
+        "selector",
+        IRNodeType.CONDITION,
+        position=(180, 0),
+        branches=[IRBranch(branch_id="true")],
+    )
+    child_code = _node(
+        "child-code",
+        IRNodeType.CODE,
+        position=(640, 0),
+        outputs=[IRVariable(name="output", var_type=IRVariableType.STRING)],
+    )
+    iteration = _node(
+        "iteration",
+        IRNodeType.LOOP_ARRAY,
+        position=(320, 0),
+        config={"iterator_selector": ["start", "items"]},
+        children=[selector, child_code],
+        child_edges=[
+            IREdge(source_node_id="iteration", target_node_id="selector", source_port="loop-function-inline-output"),
+            IREdge(source_node_id="selector", target_node_id="child-code", source_port="true"),
+            IREdge(source_node_id="child-code", target_node_id="iteration", target_port="loop-function-inline-input"),
+        ],
+    )
+    workflow = IRWorkflow(
+        nodes=[
+            _node("start", IRNodeType.START),
+            iteration,
+            _node("end", IRNodeType.END),
+        ],
+        edges=[
+            IREdge(source_node_id="start", target_node_id="iteration"),
+            IREdge(source_node_id="iteration", target_node_id="end"),
+        ],
+    )
+
+    dsl = DifyGenerator().generate(workflow)
+
+    nodes = {node.id: node for node in dsl.workflow.graph.nodes}
+    edges = dsl.workflow.graph.edges
+
+    assert nodes["iteration"].data.start_node_id == "iterationstart"
+    assert nodes["iterationstart"].parentId == "iteration"
+    assert nodes["selector"].parentId == "iteration"
+    assert nodes["child-code"].parentId == "iteration"
+    assert any(edge.source == "iterationstart" and edge.target == "selector" for edge in edges)
+    assert not any(edge.source == "child-code" and edge.target == "iteration" for edge in edges)


### PR DESCRIPTION
## Summary
- generate Dify-compatible nested iteration/loop graphs so workflow pages keep their connections after loading
- persist workflow variable columns in the shape Dify expects and recursively count composite child nodes in conversion reports
- add regression tests for nested graph export and composite-node report coverage

## Verification
- /tmp/coze2dify-review-venv/bin/pytest -q backend/tests/test_composite_graph.py
- /tmp/coze2dify-review-venv/bin/ruff check backend/tests/test_composite_graph.py backend/core/dify/generator.py backend/core/engine/converter.py backend/core/dify/models.py
- python3 -m compileall backend
- real Coze -> Dify migration rerun; opened migrated Dify workflow pages with headless browser and confirmed graph stays at 9 nodes / 7 edges with errorCount 0