### PR TITLE
Fix duplicate sync DB connection state

### DIFF
--- a/frontend/src/components/sync/SyncDashboard.tsx
+++ b/frontend/src/components/sync/SyncDashboard.tsx
@@ -1,7 +1,9 @@
-import { useSyncStore } from "../../store/conversionStore";
+import { usePlatformStore } from "../../store/platformStore";
+import { useSyncStore } from "../../store/syncStore";
 
 export default function SyncDashboard() {
-  const { syncStatus, cozeDbConnected, difyDbConnected } = useSyncStore();
+  const { syncStatus } = useSyncStore();
+  const { cozeDbConnected, difyDbConnected } = usePlatformStore();
 
   const statusColor = {
     idle: "var(--c-slate)",

--- a/frontend/src/store/syncStore.ts
+++ b/frontend/src/store/syncStore.ts
@@ -2,18 +2,10 @@ import { create } from "zustand";
 
 interface SyncState {
   syncStatus: "idle" | "running" | "completed" | "failed";
-  cozeDbConnected: boolean;
-  difyDbConnected: boolean;
   setSyncStatus: (status: SyncState["syncStatus"]) => void;
-  setCozeDbConnected: (v: boolean) => void;
-  setDifyDbConnected: (v: boolean) => void;
 }
 
 export const useSyncStore = create<SyncState>((set) => ({
   syncStatus: "idle",
-  cozeDbConnected: false,
-  difyDbConnected: false,
   setSyncStatus: (status) => set({ syncStatus: status }),
-  setCozeDbConnected: (v) => set({ cozeDbConnected: v }),
-  setDifyDbConnected: (v) => set({ difyDbConnected: v }),
 }));


### PR DESCRIPTION
## Summary
- rename the sync-specific Zustand store file to `syncStore.ts`
- keep DB connection status in `platformStore` as the single source of truth
- update the sync dashboard to read connection state from `platformStore`

## Testing
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run build`

Closes #12
