### PR TITLE
Persist frontend session state across refresh

### DIFF
--- a/frontend/src/store/platformStore.ts
+++ b/frontend/src/store/platformStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type {
   CozeWorkspace,
   CozeWorkflowItem,
@@ -56,7 +57,24 @@ interface PlatformState {
   reset: () => void;
 }
 
-export const usePlatformStore = create<PlatformState>((set) => ({
+type PlatformStoreData = Omit<
+  PlatformState,
+  | "setCozeCredentials"
+  | "setCozeConnected"
+  | "setCozeSelectedSpace"
+  | "setCozeWorkflows"
+  | "setDifyCredentials"
+  | "setDifyConnected"
+  | "setDifyApps"
+  | "setDifySelectedApp"
+  | "setCozeDb"
+  | "setDifyDb"
+  | "setDevMode"
+  | "setActiveTab"
+  | "reset"
+>;
+
+const initialState: PlatformStoreData = {
   cozeToken: "",
   cozeApiBase: "https://api.coze.com",
   cozeConnected: false,
@@ -80,7 +98,11 @@ export const usePlatformStore = create<PlatformState>((set) => ({
   detectedDify: [],
 
   activeTab: "coze",
+};
 
+export const usePlatformStore = create<PlatformState>()(
+  persist((set) => ({
+    ...initialState,
   setCozeCredentials: (token, apiBase) =>
     set({ cozeToken: token, cozeApiBase: apiBase }),
 
@@ -112,25 +134,9 @@ export const usePlatformStore = create<PlatformState>((set) => ({
   setActiveTab: (tab) => set({ activeTab: tab }),
 
   reset: () =>
-    set({
-      cozeToken: "",
-      cozeApiBase: "https://api.coze.com",
-      cozeConnected: false,
-      cozeWorkspaces: [],
-      cozeSelectedSpace: "",
-      cozeWorkflows: [],
-      difyApiBase: "",
-      difyApiKey: "",
-      difyConnected: false,
-      difyApps: [],
-      difySelectedAppId: "",
-      cozeDbUrl: "",
-      cozeDbConnected: false,
-      difyDbUrl: "",
-      difyDbConnected: false,
-      devModeEnabled: false,
-      detectedCoze: [],
-      detectedDify: [],
-      activeTab: "coze",
-    }),
-}));
+    set(initialState),
+  }), {
+    name: "coze2dify-platform",
+    storage: createJSONStorage(() => sessionStorage),
+  }),
+);

--- a/frontend/src/store/workflowStore.ts
+++ b/frontend/src/store/workflowStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { ConversionReport, WorkflowNode } from "../types/ir";
 
 interface WorkflowState {
@@ -12,13 +13,27 @@ interface WorkflowState {
   reset: () => void;
 }
 
-export const useWorkflowStore = create<WorkflowState>((set) => ({
+type WorkflowStoreData = Omit<
+  WorkflowState,
+  "setSourceMethod" | "setSourceNodes" | "setConversion" | "reset"
+>;
+
+const initialState: WorkflowStoreData = {
   sourceMethod: null,
   sourceNodes: [],
   conversionId: null,
   conversionReport: null,
+};
+
+export const useWorkflowStore = create<WorkflowState>()(
+  persist((set) => ({
+    ...initialState,
   setSourceMethod: (method) => set({ sourceMethod: method }),
   setSourceNodes: (nodes) => set({ sourceNodes: nodes }),
   setConversion: (id, report) => set({ conversionId: id, conversionReport: report }),
-  reset: () => set({ sourceMethod: null, sourceNodes: [], conversionId: null, conversionReport: null }),
-}));
+  reset: () => set(initialState),
+  }), {
+    name: "coze2dify-workflow",
+    storage: createJSONStorage(() => sessionStorage),
+  }),
+);


### PR DESCRIPTION
## Summary
- persist the platform store in `sessionStorage` so connection context survives refreshes
- persist the workflow store in `sessionStorage` so conversion context survives refreshes
- keep existing reset actions working by reusing typed initial state objects

## Testing
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run build`
- `git push -u origin biao/issue-13-persist-state` (includes the local pre-push CI gate and E2E smoke)

Closes #13
