### PR TITLE
feat: add alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Services:
 # Backend
 cd backend
 pip install -e ".[dev]"
+python -m alembic upgrade head
 uvicorn main:app --reload
 
 # Frontend (another terminal)
@@ -116,6 +117,8 @@ cd frontend
 npm install
 npm run dev
 ```
+
+If you already have a local `coze2dify.db` that was created by the old startup-time `create_all()` path, run `python -m alembic stamp head` once before applying future migrations.
 
 ## 📖 API Reference
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = %(here)s/db/alembic
+prepend_sys_path = %(here)s
+path_separator = os
+sqlalchemy.url = sqlite:///./coze2dify.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/db/alembic/env.py
+++ b/backend/db/alembic/env.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import make_url
+
+from config import settings
+from db import models as _models  # noqa: F401
+from db.database import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _get_database_url() -> str:
+    cli_args = context.get_x_argument(as_dictionary=True)
+    if cli_args.get("db_url"):
+        return cli_args["db_url"]
+
+    configured_url = config.get_main_option("sqlalchemy.url")
+    if configured_url:
+        return configured_url
+
+    return settings.database_url
+
+
+def _is_sqlite(url: str) -> bool:
+    return make_url(url).get_backend_name() == "sqlite"
+
+
+def run_migrations_offline() -> None:
+    url = _get_database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        render_as_batch=_is_sqlite(url),
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    url = _get_database_url()
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = url
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            render_as_batch=connection.dialect.name == "sqlite",
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/db/alembic/script.py.mako
+++ b/backend/db/alembic/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/db/alembic/versions/20260309_01_initial_schema.py
+++ b/backend/db/alembic/versions/20260309_01_initial_schema.py
@@ -1,0 +1,75 @@
+"""Initial project schema.
+
+Revision ID: 20260309_01
+Revises:
+Create Date: 2026-03-09 23:59:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260309_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sync_configs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("coze_db_type", sa.String(length=50), nullable=False),
+        sa.Column("coze_db_url", sa.String(length=500), nullable=False),
+        sa.Column("dify_db_url", sa.String(length=500), nullable=False),
+        sa.Column("sync_mode", sa.String(length=50), nullable=False),
+        sa.Column("cron_expression", sa.String(length=100), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "migration_tasks",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("sync_config_id", sa.Integer(), nullable=True),
+        sa.Column("source_type", sa.String(length=50), nullable=False),
+        sa.Column("source_workflow_id", sa.String(length=255), nullable=False),
+        sa.Column("source_workflow_name", sa.String(length=500), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("ir_snapshot", sa.JSON(), nullable=True),
+        sa.Column("dify_dsl", sa.TEXT(), nullable=True),
+        sa.Column("report", sa.JSON(), nullable=True),
+        sa.Column("error_message", sa.TEXT(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["sync_config_id"], ["sync_configs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "sync_histories",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("sync_config_id", sa.Integer(), nullable=False),
+        sa.Column("trigger_type", sa.String(length=50), nullable=False),
+        sa.Column("workflows_synced", sa.Integer(), nullable=False),
+        sa.Column("workflows_failed", sa.Integer(), nullable=False),
+        sa.Column("conflicts_count", sa.Integer(), nullable=False),
+        sa.Column("conflicts_resolved", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.ForeignKeyConstraint(["sync_config_id"], ["sync_configs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sync_histories")
+    op.drop_table("migration_tasks")
+    op.drop_table("sync_configs")

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+PROJECT_TABLES = {"migration_tasks", "sync_configs", "sync_histories"}
+
+
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+def test_alembic_upgrade_and_downgrade_round_trip(tmp_path) -> None:
+    db_path = tmp_path / "coze2dify-alembic.db"
+    db_url = f"sqlite:///{db_path}"
+    config = _alembic_config(db_url)
+
+    command.upgrade(config, "head")
+
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    upgraded_tables = set(inspect(engine).get_table_names())
+    engine.dispose()
+
+    assert PROJECT_TABLES.issubset(upgraded_tables)
+    assert "alembic_version" in upgraded_tables
+
+    command.downgrade(config, "base")
+
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    downgraded_tables = set(inspect(engine).get_table_names())
+    engine.dispose()
+
+    assert PROJECT_TABLES.isdisjoint(downgraded_tables)


### PR DESCRIPTION
## Summary
- add an Alembic environment under `backend/db/alembic` and check in the initial schema migration
- add a backend test that upgrades and downgrades a SQLite database through Alembic
- document how to run and stamp migrations in local development

## Testing
- `python -m pytest backend/tests -q` via temporary backend venv
- `cd backend && python -m alembic -x db_url=sqlite:////tmp/coze2dify-alembic-smoke.db upgrade head`
- `cd backend && python -m alembic -x db_url=sqlite:////tmp/coze2dify-alembic-smoke.db downgrade base`
- local pre-push gate (`./scripts/ci-local.sh`)

Closes #15
