### PR TITLE
feat: complete sync backend flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | 📊 **Visual Diff** | 🟡 Basic | Current UI shows report + mapping table, not a full graph diff |
 | 🔍 **Platform Browse** | 🚧 In Progress | Connection UI exists, workflow selection flow is not completed |
 | 🛠️ **Dev Mode** | 🟡 Experimental | Local service detection exists, but one-click workflow operations are limited |
-| 🔁 **Incremental Sync** | ❌ Planned | Sync endpoints and scheduling are mostly placeholders today |
+| 🔁 **Incremental Sync** | 🟡 Experimental | Manual sync, diff preview, conflict resolution, and cron scheduling are wired for DB-to-DB workflows |
 
 ## 📌 Current Status
 
@@ -145,14 +145,17 @@ Some endpoints below exist in the API surface but are not all fully wired in the
 
 ### Sync
 
-The sync API surface is mostly scaffolded at the moment.
+The sync API covers persisted config, manual execution, diff preview, conflict resolution, and cron scheduling.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/api/v1/sync/execute` | Placeholder endpoint |
-| `GET`  | `/api/v1/sync/status` | Basic status only |
-| `GET`  | `/api/v1/sync/history` | Placeholder response |
-| `POST` | `/api/v1/sync/diff` | Placeholder endpoint |
+| `POST` | `/api/v1/sync/config` | Persist sync config |
+| `POST` | `/api/v1/sync/execute` | Execute manual sync and persist history |
+| `GET`  | `/api/v1/sync/status` | Latest status + scheduled jobs |
+| `GET`  | `/api/v1/sync/history` | List persisted sync runs |
+| `POST` | `/api/v1/sync/schedule` | Register cron-based sync |
+| `POST` | `/api/v1/sync/diff` | Preview create/update/conflict/delete gaps |
+| `POST` | `/api/v1/sync/conflicts/{id}/resolve` | Resolve a persisted conflict |
 
 ### Dev Mode
 

--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -7,12 +7,15 @@ from sqlalchemy.orm import Session
 
 from core.coze.db_reader import CozeDbReader
 from core.dify.db_reader import DifyDbReader
+from core.sync.conflict_resolver import ConflictStrategy
+from core.sync.scheduler import SyncScheduler
 from core.sync.sync_engine import SyncEngine
-from db.database import get_db
+from db.database import SessionLocal, get_db
 from db.models import SyncConfig, SyncHistory
 
 router = APIRouter()
 sync_engine = SyncEngine()
+sync_scheduler = SyncScheduler()
 
 
 class SyncConfigRequest(BaseModel):
@@ -25,8 +28,14 @@ class SyncConfigRequest(BaseModel):
     cron_expression: str | None = None
 
 
+class SyncScheduleRequest(SyncConfigRequest):
+    cron_expression: str
+    sync_mode: str = "scheduled"
+
+
 class ConflictResolveRequest(BaseModel):
-    strategy: str = "source_wins"
+    history_id: str
+    strategy: ConflictStrategy = ConflictStrategy.SOURCE_WINS
 
 
 @router.post("/config")
@@ -67,8 +76,8 @@ async def get_sync_status(db: Session = Depends(get_db)):
     stmt = select(SyncHistory).order_by(SyncHistory.started_at.desc(), SyncHistory.id.desc())
     latest = db.execute(stmt).scalars().first()
     if latest is None:
-        return {"status": "idle", "history_id": None}
-    return {"status": latest.status, "history_id": str(latest.id)}
+        return {"status": "idle", "history_id": None, "scheduled_jobs": sync_scheduler.get_jobs()}
+    return {"status": latest.status, "history_id": str(latest.id), "scheduled_jobs": sync_scheduler.get_jobs()}
 
 
 @router.get("/history")
@@ -90,35 +99,53 @@ async def get_sync_detail(
 
 
 @router.post("/schedule")
-async def set_schedule(cron_expression: str):
-    raise HTTPException(
-        status_code=501,
-        detail="Scheduled sync is not part of the manual sync MVP.",
-    )
+async def set_schedule(
+    req: SyncScheduleRequest,
+    db: Session = Depends(get_db),
+):
+    config = _upsert_sync_config(db, req)
+    schedule = sync_scheduler.schedule(str(config.id), req.cron_expression, _scheduled_sync_callback(config.id))
+    return {"config": _serialize_config(config), "schedule": schedule}
 
 
 @router.delete("/schedule")
-async def cancel_schedule():
-    raise HTTPException(
-        status_code=501,
-        detail="Scheduled sync is not part of the manual sync MVP.",
-    )
+async def cancel_schedule(
+    config_id: int = Query(..., ge=1),
+    db: Session = Depends(get_db),
+):
+    config = db.get(SyncConfig, config_id)
+    if config is None:
+        raise HTTPException(status_code=404, detail=f"Sync config {config_id} not found")
+
+    config.enabled = False
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+
+    cancelled = sync_scheduler.cancel(str(config.id))
+    return {"config": _serialize_config(config), "cancelled": cancelled}
 
 
 @router.post("/diff")
-async def preview_diff():
-    raise HTTPException(
-        status_code=501,
-        detail="Diff preview is not part of the manual sync MVP.",
-    )
+async def preview_diff(
+    req: SyncConfigRequest,
+    db: Session = Depends(get_db),
+):
+    config = _upsert_sync_config(db, req)
+    return sync_engine.preview_diff(db, config)
 
 
 @router.post("/conflicts/{conflict_id}/resolve")
-async def resolve_conflict(conflict_id: str, req: ConflictResolveRequest):
-    raise HTTPException(
-        status_code=501,
-        detail="Conflict resolution is not part of the manual sync MVP.",
-    )
+async def resolve_conflict(
+    conflict_id: str,
+    req: ConflictResolveRequest,
+    db: Session = Depends(get_db),
+):
+    history = _get_history(db, req.history_id)
+    try:
+        return sync_engine.resolve_conflict(db, history, conflict_id=conflict_id, strategy=req.strategy)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
@@ -200,3 +227,15 @@ def _get_history(db: Session, history_id: str) -> SyncHistory:
     if history is None:
         raise HTTPException(status_code=404, detail=f"Sync history {history_id} not found")
     return history
+
+
+def _scheduled_sync_callback(config_id: int):
+    def _run() -> None:
+        with SessionLocal() as db:
+            config = db.get(SyncConfig, config_id)
+            if config is None or not config.enabled:
+                sync_scheduler.cancel(str(config_id))
+                return
+            sync_engine.execute_sync(db, config, trigger_type="schedule")
+
+    return _run

--- a/backend/core/sync/conflict_resolver.py
+++ b/backend/core/sync/conflict_resolver.py
@@ -21,8 +21,7 @@ class ConflictResolver:
         strategy: ConflictStrategy = ConflictStrategy.MANUAL,
     ) -> dict[str, Any] | None:
         if strategy == ConflictStrategy.SOURCE_WINS:
-            return source_data
-        elif strategy == ConflictStrategy.TARGET_WINS:
+            return dict(source_data)
+        if strategy == ConflictStrategy.TARGET_WINS:
             return None  # Skip, keep target
-        else:
-            return None  # Manual: needs user intervention
+        return None  # Manual: needs user intervention

--- a/backend/core/sync/scheduler.py
+++ b/backend/core/sync/scheduler.py
@@ -2,19 +2,68 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from apscheduler.job import Job
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
 
 class SyncScheduler:
     """Manages scheduled sync tasks."""
 
     def __init__(self) -> None:
-        self._jobs: dict[str, Any] = {}
+        self._scheduler = BackgroundScheduler(
+            daemon=True,
+            timezone="UTC",
+            job_defaults={"coalesce": True, "max_instances": 1},
+        )
+        self._scheduler.start()
 
-    def schedule(self, config_id: str, cron_expression: str, callback: Callable) -> None:
-        # TODO: Integrate APScheduler
-        self._jobs[config_id] = {"cron": cron_expression, "callback": callback}
+    def schedule(self, config_id: str, cron_expression: str, callback: Callable[[], None]) -> dict[str, Any]:
+        trigger = CronTrigger.from_crontab(cron_expression, timezone="UTC")
+        job = self._scheduler.add_job(
+            callback,
+            trigger=trigger,
+            id=self._job_id(config_id),
+            name=f"sync:{config_id}",
+            replace_existing=True,
+        )
+        return self._serialize_job(job, config_id, cron_expression)
 
-    def cancel(self, config_id: str) -> None:
-        self._jobs.pop(config_id, None)
+    def cancel(self, config_id: str) -> bool:
+        job_id = self._job_id(config_id)
+        job = self._scheduler.get_job(job_id)
+        if job is None:
+            return False
+        self._scheduler.remove_job(job_id)
+        return True
 
-    def get_jobs(self) -> dict[str, Any]:
-        return self._jobs.copy()
+    def get_job(self, config_id: str) -> dict[str, Any] | None:
+        job = self._scheduler.get_job(self._job_id(config_id))
+        if job is None:
+            return None
+        return self._serialize_job(job, config_id)
+
+    def get_jobs(self) -> list[dict[str, Any]]:
+        jobs: list[dict[str, Any]] = []
+        for job in self._scheduler.get_jobs():
+            config_id = job.id.removeprefix("sync-config-")
+            jobs.append(self._serialize_job(job, config_id))
+        return jobs
+
+    def shutdown(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+
+    @staticmethod
+    def _job_id(config_id: str) -> str:
+        return f"sync-config-{config_id}"
+
+    @staticmethod
+    def _serialize_job(job: Job, config_id: str, cron_expression: str | None = None) -> dict[str, Any]:
+        resolved_config_id: int | str = int(config_id) if str(config_id).isdigit() else config_id
+        return {
+            "config_id": resolved_config_id,
+            "job_id": job.id,
+            "cron_expression": cron_expression or str(job.trigger),
+            "next_run_at": job.next_run_time.isoformat() if job.next_run_time else None,
+        }

--- a/backend/core/sync/sync_engine.py
+++ b/backend/core/sync/sync_engine.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Session
 from core.coze.db_reader import CozeDbReader
 from core.dify.db_reader import DifyDbReader
 from core.engine.conversion_service import ConversionService
+from core.sync.conflict_resolver import ConflictResolver, ConflictStrategy
+from core.sync.diff_detector import DiffDetector
 from db.models import MigrationTask, SyncConfig, SyncHistory
 
 
@@ -27,10 +29,14 @@ class SyncEngine:
         *,
         coze_reader_factory: Callable[[str], CozeDbReader] = CozeDbReader,
         dify_reader_factory: Callable[[str], DifyDbReader] = DifyDbReader,
+        diff_detector: DiffDetector | None = None,
+        conflict_resolver: ConflictResolver | None = None,
     ) -> None:
         self.conversion_service = conversion_service or ConversionService()
         self.coze_reader_factory = coze_reader_factory
         self.dify_reader_factory = dify_reader_factory
+        self.diff_detector = diff_detector or DiffDetector()
+        self.conflict_resolver = conflict_resolver or ConflictResolver()
 
     def execute_sync(
         self,
@@ -216,6 +222,286 @@ class SyncEngine:
 
         return self.serialize_history(history, include_items=True)
 
+    def preview_diff(self, db: Session, config: SyncConfig) -> dict[str, Any]:
+        summary = self._empty_summary()
+        items: list[dict[str, Any]] = []
+
+        source_reader = self.coze_reader_factory(config.coze_db_url)
+        dify_reader = self.dify_reader_factory(config.dify_db_url)
+        source_workflows = source_reader.list_workflows()
+        target_apps = dify_reader.list_apps()
+        mappings = self._load_existing_mappings(db, config.id)
+        duplicate_target_app_ids = self._find_duplicate_target_app_ids(mappings)
+        source_ids = {self._workflow_id(workflow) for workflow in source_workflows if self._workflow_id(workflow)}
+        target_apps_by_id = {str(app.get("app_id") or ""): app for app in target_apps if app.get("app_id")}
+        target_names = self._index_target_names(target_apps)
+
+        items.extend(self._collect_delete_gaps(mappings, source_ids, target_apps_by_id, summary))
+
+        source_snapshots: dict[str, dict[str, Any]] = {}
+        target_snapshots: dict[str, dict[str, Any]] = {}
+        candidates: dict[str, dict[str, Any]] = {}
+
+        for workflow in source_workflows:
+            source_id = self._workflow_id(workflow)
+            source_name = str(workflow.get("name") or source_id or "Unknown workflow")
+
+            if not source_id:
+                items.append(
+                    self._result_item(
+                        action="inspect",
+                        status="failed",
+                        source_workflow_id="",
+                        source_workflow_name=source_name,
+                        message="Coze workflow is missing workflow_id; diff preview cannot continue safely.",
+                    )
+                )
+                summary["failed"] += 1
+                continue
+
+            mapping = mappings.get(source_id)
+            if mapping and mapping["app_id"] in duplicate_target_app_ids:
+                items.append(
+                    self._result_item(
+                        action="update",
+                        status="conflict",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=mapping["app_id"],
+                        message="Multiple source workflows map to the same Dify app. Resolve the mapping before syncing.",
+                    )
+                )
+                summary["conflicts"] += 1
+                continue
+
+            if mapping is None:
+                name_matches = target_names.get(self._normalize_name(source_name), [])
+                if name_matches:
+                    items.append(
+                        self._result_item(
+                            action="create",
+                            status="conflict",
+                            source_workflow_id=source_id,
+                            source_workflow_name=source_name,
+                            target_app_id=name_matches[0]["app_id"] if len(name_matches) == 1 else None,
+                            message=(
+                                "Found existing Dify app names that collide with this workflow. "
+                                "Resolve the conflict before syncing."
+                            ),
+                        )
+                    )
+                    summary["conflicts"] += 1
+                    continue
+
+            try:
+                converted = self._convert_source_workflow(source_reader, source_id)
+            except Exception as exc:  # noqa: BLE001 - diff preview should surface actionable failures
+                items.append(
+                    self._result_item(
+                        action="inspect",
+                        status="failed",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=mapping["app_id"] if mapping else None,
+                        message=str(exc),
+                    )
+                )
+                summary["failed"] += 1
+                continue
+
+            source_snapshots[source_id] = self._normalized_dsl_payload(converted["dsl"])
+            if mapping and mapping["app_id"] in target_apps_by_id:
+                target_workflow = dify_reader.read_workflow(mapping["app_id"])
+                if target_workflow is not None:
+                    target_snapshots[source_id] = self._normalized_target_payload(target_workflow)
+
+            candidates[source_id] = {
+                "source_workflow_name": converted["source_workflow_name"] or source_name,
+                "target_app_id": mapping["app_id"] if mapping else None,
+                "had_mapping": bool(mapping),
+                "target_exists": bool(mapping and mapping["app_id"] in target_apps_by_id),
+            }
+
+        new_ids, updated_ids, _ = self.diff_detector.detect_changes(source_snapshots, target_snapshots)
+        new_set = set(new_ids)
+        updated_set = set(updated_ids)
+        unchanged_set = (set(source_snapshots) & set(target_snapshots)) - updated_set
+
+        for workflow in source_workflows:
+            source_id = self._workflow_id(workflow)
+            if source_id not in candidates:
+                continue
+
+            candidate = candidates[source_id]
+            source_name = str(candidate["source_workflow_name"] or workflow.get("name") or source_id)
+            target_app_id = candidate["target_app_id"]
+            had_mapping = bool(candidate["had_mapping"])
+            target_exists = bool(candidate["target_exists"])
+
+            if source_id in new_set:
+                summary["created"] += 1
+                message = (
+                    "Existing sync mapping points to a missing Dify app. The next sync run will recreate it."
+                    if had_mapping and not target_exists
+                    else "No matching Dify app was found. The next sync run will create one."
+                )
+                items.append(
+                    self._result_item(
+                        action="create",
+                        status="created",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=target_app_id if target_exists else None,
+                        message=message,
+                    )
+                )
+            elif source_id in updated_set:
+                summary["updated"] += 1
+                items.append(
+                    self._result_item(
+                        action="update",
+                        status="updated",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=target_app_id,
+                        message="Diff preview detected changes between the converted source workflow and the Dify target.",
+                    )
+                )
+            elif source_id in unchanged_set:
+                summary["skipped"] += 1
+                items.append(
+                    self._result_item(
+                        action="skip",
+                        status="skipped",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=target_app_id,
+                        message="No changes detected between the converted source workflow and the current Dify target.",
+                    )
+                )
+
+        return {
+            "config_id": config.id,
+            "summary": summary,
+            "items": items,
+            "status": self._derive_status(summary),
+        }
+
+    def resolve_conflict(
+        self,
+        db: Session,
+        history: SyncHistory,
+        *,
+        conflict_id: str,
+        strategy: ConflictStrategy,
+    ) -> dict[str, Any]:
+        payload = history.conflicts_resolved or {}
+        items = list(payload.get("items") or [])
+        summary = {
+            **self._empty_summary(),
+            **(payload.get("summary") or {}),
+        }
+        config = history.sync_config
+        if config is None:
+            raise LookupError(f"Sync config {history.sync_config_id} not found")
+
+        index = next(
+            (
+                idx
+                for idx, item in enumerate(items)
+                if item.get("source_workflow_id") == conflict_id and item.get("status") == "conflict"
+            ),
+            None,
+        )
+        if index is None:
+            raise LookupError(f"Conflict {conflict_id} not found in sync history {history.id}")
+
+        conflict_item = dict(items[index])
+        target_app_id = conflict_item.get("target_app_id")
+        source_reader = self.coze_reader_factory(config.coze_db_url)
+        dify_reader = self.dify_reader_factory(config.dify_db_url)
+
+        source_payload = source_reader.read_workflow(conflict_id)
+        if source_payload is None:
+            raise LookupError(f"Workflow {conflict_id} not found in Coze database")
+
+        target_payload = dify_reader.read_workflow(target_app_id) if target_app_id else {}
+        resolved_payload = self.conflict_resolver.resolve(
+            conflict_id,
+            source_payload,
+            target_payload or {},
+            strategy,
+        )
+
+        if strategy == ConflictStrategy.MANUAL:
+            conflict_item["resolution"] = {
+                "strategy": strategy.value,
+                "resolved_at": _utcnow().isoformat(),
+                "status": "pending_manual_review",
+            }
+            items[index] = conflict_item
+            history.conflicts_resolved = {"summary": summary, "items": items}
+            db.add(history)
+            db.commit()
+            db.refresh(history)
+            return self.serialize_history(history, include_items=True)
+
+        summary["conflicts"] = max(0, int(summary.get("conflicts") or 0) - 1)
+
+        if strategy == ConflictStrategy.TARGET_WINS or resolved_payload is None:
+            summary["skipped"] += 1
+            conflict_item.update(
+                {
+                    "action": "keep",
+                    "status": "skipped",
+                    "message": "Conflict resolved by keeping the existing Dify target unchanged.",
+                    "resolution": {
+                        "strategy": strategy.value,
+                        "resolved_at": _utcnow().isoformat(),
+                        "status": "kept_target",
+                    },
+                }
+            )
+        else:
+            write_result = self._resolve_conflict_with_source(
+                db,
+                config,
+                conflict_id=conflict_id,
+                target_app_id=target_app_id,
+            )
+            final_status = "updated" if write_result["mode"] == "update" else "created"
+            summary[final_status] += 1
+            history.workflows_synced += 1
+            conflict_item.update(
+                {
+                    "action": write_result["mode"],
+                    "status": final_status,
+                    "target_app_id": write_result["app_id"],
+                    "conversion_id": write_result["conversion_id"],
+                    "message": (
+                        "Conflict resolved by applying the source workflow to the existing Dify target."
+                        if write_result["mode"] == "update"
+                        else "Conflict resolved by creating a fresh Dify workflow from the source."
+                    ),
+                    "resolution": {
+                        "strategy": strategy.value,
+                        "resolved_at": _utcnow().isoformat(),
+                        "status": "applied_source",
+                    },
+                }
+            )
+
+        items[index] = conflict_item
+        history.workflows_failed = summary["failed"]
+        history.conflicts_count = summary["conflicts"]
+        history.conflicts_resolved = {"summary": summary, "items": items}
+        history.completed_at = _utcnow()
+        history.status = self._derive_status(summary)
+        db.add(history)
+        db.commit()
+        db.refresh(history)
+        return self.serialize_history(history, include_items=True)
+
     @staticmethod
     def serialize_history(history: SyncHistory, *, include_items: bool = False) -> dict[str, Any]:
         payload = history.conflicts_resolved or {}
@@ -312,17 +598,62 @@ class SyncEngine:
 
     @classmethod
     def _is_unchanged(cls, conversion: dict[str, Any], target_workflow: dict[str, Any]) -> bool:
-        dsl_payload = conversion.get("dsl") or {}
+        return cls._fingerprint(cls._normalized_dsl_payload(conversion.get("dsl") or {})) == cls._fingerprint(
+            cls._normalized_target_payload(target_workflow)
+        )
+
+    def _resolve_conflict_with_source(
+        self,
+        db: Session,
+        config: SyncConfig,
+        *,
+        conflict_id: str,
+        target_app_id: str | None,
+    ) -> dict[str, Any]:
+        conversion = self.conversion_service.convert_from_db(
+            db,
+            db_url=config.coze_db_url,
+            workflow_id=conflict_id,
+        )
+        conversion_id = str(conversion["conversion_id"])
+        self._attach_sync_config(db, conversion_id, config.id)
+        return self.conversion_service.write_to_dify(
+            db,
+            conversion_id,
+            db_url=config.dify_db_url,
+            app_id=target_app_id,
+        )
+
+    def _convert_source_workflow(self, source_reader: CozeDbReader, workflow_id: str) -> dict[str, Any]:
+        payload = source_reader.read_workflow(workflow_id)
+        if payload is None:
+            raise LookupError(f"Workflow {workflow_id} not found in Coze database")
+
+        canvas = self.conversion_service._extract_canvas(payload)
+        ir_workflow = self.conversion_service.engine.coze_parser.parse_dict(canvas)
+        dify_dsl, _report = self.conversion_service.engine.convert_from_ir(ir_workflow)
+        source_workflow_name = ""
+        if isinstance(payload, dict):
+            source_workflow_name = str(payload.get("name") or "")
+        return {
+            "dsl": dify_dsl.model_dump(mode="json"),
+            "source_workflow_name": source_workflow_name or ir_workflow.name or workflow_id,
+        }
+
+    @staticmethod
+    def _normalized_dsl_payload(dsl_payload: dict[str, Any]) -> dict[str, Any]:
         workflow_payload = dsl_payload.get("workflow") if isinstance(dsl_payload, dict) else {}
-        source_payload = {
+        return {
             "graph": workflow_payload.get("graph"),
             "features": workflow_payload.get("features") or {},
         }
-        target_payload = {
+
+    @staticmethod
+    def _normalized_target_payload(target_workflow: dict[str, Any]) -> dict[str, Any]:
+        return {
             "graph": target_workflow.get("graph"),
             "features": target_workflow.get("features") or {},
         }
-        return cls._fingerprint(source_payload) == cls._fingerprint(target_payload)
 
     @staticmethod
     def _find_duplicate_target_app_ids(mappings: dict[str, dict[str, Any]]) -> set[str]:

--- a/backend/tests/test_sync_api.py
+++ b/backend/tests/test_sync_api.py
@@ -7,9 +7,11 @@ from sqlalchemy.orm import sessionmaker
 
 from api.endpoints import sync as sync_endpoints
 from api.router import api_router
+from core.sync.conflict_resolver import ConflictStrategy
+from core.sync.scheduler import SyncScheduler
 from core.sync.sync_engine import SyncEngine
 from db.database import Base, get_db
-from db.models import MigrationTask, SyncHistory
+from db.models import MigrationTask, SyncConfig, SyncHistory
 
 
 def _utcnow() -> datetime:
@@ -163,3 +165,170 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
     assert histories[0].workflows_synced == 1
     assert len(tasks) == 1
     assert tasks[0].sync_config_id == histories[0].sync_config_id
+
+
+def test_sync_schedule_diff_and_conflict_endpoints_are_wired(tmp_path, monkeypatch) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-api-extra.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    def override_get_db():
+        with session_factory() as db:
+            yield db
+
+    class StubSyncEngine:
+        def preview_diff(self, db, config):
+            return {
+                "config_id": config.id,
+                "status": "partial",
+                "summary": {
+                    "created": 1,
+                    "updated": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unsupported": 0,
+                    "conflicts": 1,
+                },
+                "items": [
+                    {
+                        "action": "create",
+                        "status": "created",
+                        "source_workflow_id": "wf-create",
+                        "source_workflow_name": "Create Flow",
+                        "target_app_id": None,
+                        "conversion_id": None,
+                        "message": "Will create on next sync.",
+                    }
+                ],
+            }
+
+        def resolve_conflict(self, db, history, *, conflict_id: str, strategy: ConflictStrategy):
+            payload = dict(history.conflicts_resolved)
+            summary = dict(payload["summary"])
+            item = dict(payload["items"][0])
+            item["status"] = "skipped"
+            item["action"] = "keep"
+            item["resolution"] = {
+                "strategy": strategy.value,
+                "status": "kept_target",
+            }
+            summary["conflicts"] = 0
+            summary["skipped"] = 1
+            history.conflicts_count = 0
+            history.status = "completed"
+            history.conflicts_resolved = {
+                "summary": summary,
+                "items": [item],
+            }
+            db.add(history)
+            db.commit()
+            db.refresh(history)
+            return {
+                "id": str(history.id),
+                "sync_config_id": history.sync_config_id,
+                "sync_config_name": history.sync_config.name if history.sync_config else None,
+                "trigger_type": history.trigger_type,
+                "status": history.status,
+                "started_at": history.started_at.isoformat() if history.started_at else None,
+                "completed_at": history.completed_at.isoformat() if history.completed_at else None,
+                "workflows_synced": history.workflows_synced,
+                "workflows_failed": history.workflows_failed,
+                "conflicts_count": history.conflicts_count,
+                "summary": history.conflicts_resolved["summary"],
+                "items": history.conflicts_resolved["items"],
+            }
+
+        def execute_sync(self, db, config, *, trigger_type: str = "manual"):
+            return {"id": "unused", "status": "completed"}
+
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api/v1")
+    app.dependency_overrides[get_db] = override_get_db
+
+    scheduler = SyncScheduler()
+    monkeypatch.setattr(sync_endpoints, "sync_engine", StubSyncEngine())
+    monkeypatch.setattr(sync_endpoints, "sync_scheduler", scheduler)
+
+    client = TestClient(app)
+    schedule_payload = {
+        "name": "Nightly Sync",
+        "coze_db_url": "postgresql://coze.test/app",
+        "dify_db_url": "postgresql://dify.test/app",
+        "cron_expression": "0 3 * * *",
+    }
+
+    schedule_response = client.post("/api/v1/sync/schedule", json=schedule_payload)
+    assert schedule_response.status_code == 200
+    schedule_data = schedule_response.json()
+    config_id = schedule_data["config"]["id"]
+    assert schedule_data["config"]["sync_mode"] == "scheduled"
+    assert schedule_data["schedule"]["config_id"] == config_id
+
+    diff_response = client.post(
+        "/api/v1/sync/diff",
+        json={
+            "config_id": config_id,
+            "name": "Nightly Sync",
+            "coze_db_url": "postgresql://coze.test/app",
+            "dify_db_url": "postgresql://dify.test/app",
+        },
+    )
+    assert diff_response.status_code == 200
+    assert diff_response.json()["summary"]["created"] == 1
+
+    with session_factory() as db:
+        config = db.get(SyncConfig, config_id)
+        history = SyncHistory(
+            sync_config_id=config_id,
+            trigger_type="manual",
+            status="partial",
+            conflicts_count=1,
+            conflicts_resolved={
+                "summary": {
+                    "created": 0,
+                    "updated": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unsupported": 0,
+                    "conflicts": 1,
+                },
+                "items": [
+                    {
+                        "action": "update",
+                        "status": "conflict",
+                        "source_workflow_id": "wf-conflict",
+                        "source_workflow_name": "Conflict Flow",
+                        "target_app_id": "app-existing",
+                        "conversion_id": None,
+                        "message": "Resolve me.",
+                    }
+                ],
+            },
+            started_at=_utcnow(),
+        )
+        db.add(history)
+        db.commit()
+        db.refresh(history)
+        history_id = history.id
+        assert config is not None
+
+    conflict_response = client.post(
+        "/api/v1/sync/conflicts/wf-conflict/resolve",
+        json={"history_id": str(history_id), "strategy": "target_wins"},
+    )
+    assert conflict_response.status_code == 200
+    assert conflict_response.json()["items"][0]["status"] == "skipped"
+
+    status_response = client.get("/api/v1/sync/status")
+    assert status_response.status_code == 200
+    assert status_response.json()["scheduled_jobs"][0]["config_id"] == config_id
+
+    cancel_response = client.delete(f"/api/v1/sync/schedule?config_id={config_id}")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["cancelled"] is True
+    assert cancel_response.json()["config"]["enabled"] is False
+
+    scheduler.shutdown()

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -4,6 +4,8 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from core.sync.sync_engine import SyncEngine
+from core.sync.conflict_resolver import ConflictStrategy
+from core.engine.conversion_service import ConversionService
 from db.database import Base
 from db.models import MigrationTask, SyncConfig, SyncHistory
 
@@ -21,6 +23,13 @@ class FakeCozeReader:
             {"id": "wf-create", "name": "Create Flow"},
             {"id": "wf-update", "name": "Update Flow"},
         ]
+
+    def read_workflow(self, workflow_id: str) -> dict[str, object] | None:
+        return {
+            "id": workflow_id,
+            "name": f"Workflow {workflow_id}",
+            "canvas": _minimal_canvas(workflow_id),
+        }
 
 
 class FakeDifyReader:
@@ -48,6 +57,48 @@ class FakeDifyReader:
             "graph": {"nodes": [{"id": "old-node"}], "edges": []},
             "features": {"mode": "old"},
         }
+
+
+class PreviewCozeReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_workflows(self) -> list[dict[str, str]]:
+        return [
+            {"id": "wf-create", "name": "Create Flow"},
+            {"id": "wf-update", "name": "Update Flow"},
+            {"id": "wf-skip", "name": "Skip Flow"},
+            {"id": "wf-conflict", "name": "Name Collision"},
+        ]
+
+    def read_workflow(self, workflow_id: str) -> dict[str, object] | None:
+        canvas = _minimal_canvas(workflow_id)
+        return {
+            "id": workflow_id,
+            "name": {
+                "wf-create": "Create Flow",
+                "wf-update": "Update Flow",
+                "wf-skip": "Skip Flow",
+                "wf-conflict": "Name Collision",
+            }[workflow_id],
+            "canvas": canvas,
+        }
+
+
+class PreviewDifyReader:
+    def __init__(self, db_url: str, workflows: dict[str, dict[str, object]]) -> None:
+        self.db_url = db_url
+        self.workflows = workflows
+
+    def list_apps(self) -> list[dict[str, str]]:
+        return [
+            {"app_id": "app-update", "name": "Update Flow"},
+            {"app_id": "app-skip", "name": "Skip Flow"},
+            {"app_id": "app-name-collision", "name": "Name Collision"},
+        ]
+
+    def read_workflow(self, app_id: str) -> dict[str, object] | None:
+        return self.workflows.get(app_id)
 
 
 class FakeConversionService:
@@ -111,6 +162,36 @@ class FakeConversionService:
             "mode": mode,
             "status": task.status,
         }
+
+
+def _minimal_canvas(node_id: str) -> dict[str, object]:
+    start_id = f"{node_id}-start"
+    end_id = f"{node_id}-end"
+    return {
+        "nodes": [
+            {
+                "id": start_id,
+                "type": "1",
+                "meta": {"position": {"x": 0, "y": 0}},
+                "data": {"outputs": [{"type": "string", "name": "input", "required": True}]},
+            },
+            {
+                "id": end_id,
+                "type": "2",
+                "meta": {"position": {"x": 320, "y": 0}},
+                "data": {"inputs": {"terminatePlan": "useAnswerContent"}},
+            },
+        ],
+        "edges": [{"sourceNodeID": start_id, "targetNodeID": end_id}],
+        "versions": {},
+    }
+
+
+def _dsl_payload_for(canvas: dict[str, object]) -> dict[str, object]:
+    service = ConversionService()
+    ir_workflow = service.engine.coze_parser.parse_dict(canvas)
+    dsl, _report = service.engine.convert_from_ir(ir_workflow)
+    return dsl.model_dump(mode="json")
 
 
 def test_execute_sync_persists_create_and_update_results(tmp_path) -> None:
@@ -179,3 +260,176 @@ def test_execute_sync_persists_create_and_update_results(tmp_path) -> None:
         ("2", "postgresql://dify.test/app", None),
         ("3", "postgresql://dify.test/app", "app-existing"),
     ]
+
+
+def test_preview_diff_detects_create_update_skip_and_conflict_without_persisting_tasks(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-preview.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    skip_payload = _dsl_payload_for(_minimal_canvas("wf-skip"))
+    update_payload = _dsl_payload_for(_minimal_canvas("wf-update"))
+    update_workflow = {
+        "app_id": "app-update",
+        "graph": {"nodes": [{"id": "changed-node"}], "edges": []},
+        "features": update_payload["workflow"]["features"],
+    }
+    skip_workflow = {
+        "app_id": "app-skip",
+        "graph": skip_payload["workflow"]["graph"],
+        "features": skip_payload["workflow"]["features"],
+    }
+
+    sync_engine = SyncEngine(
+        ConversionService(),
+        coze_reader_factory=PreviewCozeReader,
+        dify_reader_factory=lambda db_url: PreviewDifyReader(
+            db_url,
+            {"app-update": update_workflow, "app-skip": skip_workflow},
+        ),
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Diff Preview",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        db.add_all(
+            [
+                MigrationTask(
+                    sync_config_id=config.id,
+                    source_type="database",
+                    source_workflow_id="wf-update",
+                    source_workflow_name="Update Flow",
+                    status="written",
+                    ir_snapshot={"write_result": {"app_id": "app-update", "mode": "create"}},
+                    dify_dsl="workflow: {}\n",
+                    report={},
+                    completed_at=_utcnow(),
+                ),
+                MigrationTask(
+                    sync_config_id=config.id,
+                    source_type="database",
+                    source_workflow_id="wf-skip",
+                    source_workflow_name="Skip Flow",
+                    status="written",
+                    ir_snapshot={"write_result": {"app_id": "app-skip", "mode": "create"}},
+                    dify_dsl="workflow: {}\n",
+                    report={},
+                    completed_at=_utcnow(),
+                ),
+            ]
+        )
+        db.commit()
+
+        result = sync_engine.preview_diff(db, config)
+        task_count = db.execute(select(MigrationTask)).scalars().all()
+
+    assert result["status"] == "partial"
+    assert result["summary"] == {
+        "created": 1,
+        "updated": 1,
+        "failed": 0,
+        "skipped": 1,
+        "unsupported": 0,
+        "conflicts": 1,
+    }
+    assert {item["source_workflow_id"] for item in result["items"]} == {
+        "wf-create",
+        "wf-update",
+        "wf-skip",
+        "wf-conflict",
+    }
+    assert len(task_count) == 2
+
+
+def test_resolve_conflict_source_wins_updates_history_and_persists_resolution(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-conflict.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    conversion_service = FakeConversionService()
+    sync_engine = SyncEngine(
+        conversion_service,
+        coze_reader_factory=FakeCozeReader,
+        dify_reader_factory=FakeDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Conflict Sync",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        history = SyncHistory(
+            sync_config_id=config.id,
+            trigger_type="manual",
+            workflows_synced=0,
+            workflows_failed=0,
+            conflicts_count=1,
+            status="partial",
+            conflicts_resolved={
+                "summary": {
+                    "created": 0,
+                    "updated": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unsupported": 0,
+                    "conflicts": 1,
+                },
+                "items": [
+                    {
+                        "action": "update",
+                        "status": "conflict",
+                        "source_workflow_id": "wf-update",
+                        "source_workflow_name": "Update Flow",
+                        "target_app_id": "app-existing",
+                        "conversion_id": None,
+                        "message": "Manual resolution required.",
+                    }
+                ],
+            },
+            started_at=_utcnow(),
+        )
+        db.add(history)
+        db.commit()
+        db.refresh(history)
+
+        result = sync_engine.resolve_conflict(
+            db,
+            history,
+            conflict_id="wf-update",
+            strategy=ConflictStrategy.SOURCE_WINS,
+        )
+
+        refreshed_history = db.get(SyncHistory, history.id)
+
+    assert result["status"] == "completed"
+    assert result["summary"] == {
+        "created": 0,
+        "updated": 1,
+        "failed": 0,
+        "skipped": 0,
+        "unsupported": 0,
+        "conflicts": 0,
+    }
+    assert result["items"][0]["status"] == "updated"
+    assert result["items"][0]["resolution"]["strategy"] == "source_wins"
+    assert refreshed_history is not None
+    assert refreshed_history.workflows_synced == 1
+    assert refreshed_history.conflicts_count == 0
+    assert conversion_service.write_calls == [("1", "postgresql://dify.test/app", "app-existing")]

--- a/docs/api.md
+++ b/docs/api.md
@@ -181,7 +181,11 @@ Set up scheduled sync (cron expression).
 
 ### `DELETE /sync/schedule`
 
-Cancel scheduled sync.
+Cancel scheduled sync for a persisted config.
+
+**Query params:**
+
+- `config_id`: sync config primary key
 
 ### `POST /sync/diff`
 
@@ -194,6 +198,7 @@ Manually resolve a sync conflict.
 **Request:**
 ```json
 {
+  "history_id": "12",
   "strategy": "source_wins"
 }
 ```


### PR DESCRIPTION
## Summary
- wire the remaining sync backend endpoints to real implementations for scheduling, diff preview, and conflict resolution
- replace the in-memory scheduler stub with APScheduler-backed cron jobs and expose scheduled jobs from sync status
- add sync backend coverage for preview diff, conflict resolution, and API wiring, plus update sync docs

## Testing
- temporary backend venv: `ruff check . && pytest -q`
- temporary backend venv: `python -c "from main import app; print('OK')"`
- local pre-push gate (`./scripts/ci-local.sh`)

Closes #10
