### PR TITLE
feat: harden sync and direct-write safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Some endpoints below exist in the API surface but are not all fully wired in the
 | `POST` | `/api/v1/coze/upload` | Upload Coze workflow file |
 | `POST` | `/api/v1/convert` | Execute conversion |
 | `GET`  | `/api/v1/convert/{id}/dsl` | Download Dify DSL |
-| `POST` | `/api/v1/convert/{id}/write-to-dify` | Reserved endpoint; public API flow not fully implemented yet |
+| `POST` | `/api/v1/convert/{id}/write-to-dify` | Write converted DSL directly to Dify PostgreSQL |
 
 ### Sync
 
@@ -156,6 +156,13 @@ The sync API covers persisted config, manual execution, diff preview, conflict r
 | `POST` | `/api/v1/sync/schedule` | Register cron-based sync |
 | `POST` | `/api/v1/sync/diff` | Preview create/update/conflict/delete gaps |
 | `POST` | `/api/v1/sync/conflicts/{id}/resolve` | Resolve a persisted conflict |
+
+### Safety Notes
+
+- Sync config and direct-write responses no longer echo raw database URLs; API payloads return redacted `display_url` references instead.
+- Persisted sync runs and conversion tasks now carry operator audit metadata, including redacted source/target DB references and the latest write attempt details.
+- Reusing a saved sync config from the UI does not require re-entering the stored DB URL; leaving the redacted field blank keeps the persisted value unchanged.
+- Direct DB writes and sync remain operator-driven workflows. Treat them as privileged actions, and keep them behind trusted environments and credentials management.
 
 ### Dev Mode
 

--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from core.coze.db_reader import CozeDbReader
 from core.dify.db_reader import DifyDbReader
+from core.security.redaction import build_database_ref, sanitize_exception
 from core.sync.conflict_resolver import ConflictStrategy
 from core.sync.scheduler import SyncScheduler
 from core.sync.sync_engine import SyncEngine
@@ -58,10 +59,17 @@ async def get_sync_config(db: Session = Depends(get_db)):
 
 
 @router.post("/config/test")
-async def test_connections(req: SyncConfigRequest):
+async def test_connections(
+    req: SyncConfigRequest,
+    db: Session = Depends(get_db),
+):
+    config = db.get(SyncConfig, req.config_id) if req.config_id is not None else None
+    if req.config_id is not None and config is None:
+        raise HTTPException(status_code=404, detail=f"Sync config {req.config_id} not found")
+    coze_db_url, dify_db_url = _resolve_requested_urls(config, req)
     return {
-        "coze_db": _test_connection(CozeDbReader, req.coze_db_url),
-        "dify_db": _test_connection(DifyDbReader, req.dify_db_url),
+        "coze_db": _test_connection(CozeDbReader, coze_db_url),
+        "dify_db": _test_connection(DifyDbReader, dify_db_url),
     }
 
 
@@ -170,12 +178,14 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
         )
         config = db.execute(stmt).scalars().first()
 
+    coze_db_url, dify_db_url = _resolve_requested_urls(config, req)
+
     if config is None:
         config = SyncConfig(
             name=req.name.strip() or "Manual Sync",
             coze_db_type=req.coze_db_type,
-            coze_db_url=req.coze_db_url,
-            dify_db_url=req.dify_db_url,
+            coze_db_url=coze_db_url,
+            dify_db_url=dify_db_url,
             sync_mode=req.sync_mode,
             cron_expression=req.cron_expression,
             enabled=True,
@@ -183,8 +193,8 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
     else:
         config.name = req.name.strip() or config.name or "Manual Sync"
         config.coze_db_type = req.coze_db_type
-        config.coze_db_url = req.coze_db_url
-        config.dify_db_url = req.dify_db_url
+        config.coze_db_url = coze_db_url
+        config.dify_db_url = dify_db_url
         config.sync_mode = req.sync_mode
         config.cron_expression = req.cron_expression
         config.enabled = True
@@ -195,15 +205,17 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
     return config
 
 
-def _serialize_config(config: SyncConfig | None) -> dict[str, str | int | bool | None] | None:
+def _serialize_config(config: SyncConfig | None) -> dict[str, object] | None:
     if config is None:
         return None
     return {
         "id": config.id,
         "name": config.name,
         "coze_db_type": config.coze_db_type,
-        "coze_db_url": config.coze_db_url,
-        "dify_db_url": config.dify_db_url,
+        "coze_db": build_database_ref(config.coze_db_url),
+        "dify_db": build_database_ref(config.dify_db_url),
+        "has_stored_coze_db_url": bool(config.coze_db_url),
+        "has_stored_dify_db_url": bool(config.dify_db_url),
         "sync_mode": config.sync_mode,
         "cron_expression": config.cron_expression,
         "enabled": config.enabled,
@@ -217,7 +229,29 @@ def _test_connection(reader_cls: type[CozeDbReader] | type[DifyDbReader], db_url
         connected = reader_cls(db_url).test_connection()
         return {"connected": connected, "error": None if connected else "Connection test failed"}
     except Exception as exc:  # noqa: BLE001 - return actionable UI error
-        return {"connected": False, "error": str(exc)}
+        return {"connected": False, "error": sanitize_exception(exc, db_urls=[db_url])}
+
+
+def _resolve_requested_urls(
+    config: SyncConfig | None,
+    req: SyncConfigRequest,
+) -> tuple[str, str]:
+    coze_db_url = req.coze_db_url.strip()
+    dify_db_url = req.dify_db_url.strip()
+
+    if config is not None:
+        if not coze_db_url:
+            coze_db_url = config.coze_db_url
+        if not dify_db_url:
+            dify_db_url = config.dify_db_url
+
+    if not coze_db_url or not dify_db_url:
+        raise HTTPException(
+            status_code=400,
+            detail="Both Coze and Dify database URLs are required. Re-enter the redacted value to replace it.",
+        )
+
+    return coze_db_url, dify_db_url
 
 
 def _get_history(db: Session, history_id: str) -> SyncHistory:

--- a/backend/core/engine/conversion_service.py
+++ b/backend/core/engine/conversion_service.py
@@ -12,6 +12,7 @@ from core.coze.api_client import CozeApiClient
 from core.coze.db_reader import CozeDbReader
 from core.dify.db_writer import DifyDbWriter
 from core.dify.models import DifyDSL
+from core.security.redaction import build_database_ref, sanitize_exception
 from db.models import MigrationTask
 
 from .converter import ConversionEngine
@@ -78,7 +79,7 @@ class ConversionService:
 
     def get_conversion(self, db: Session, conversion_id: str) -> dict[str, Any]:
         task = self._get_task(db, conversion_id)
-        snapshot = task.ir_snapshot or {}
+        snapshot = dict(task.ir_snapshot or {})
         dsl_payload = snapshot.get("dify_dsl")
         if dsl_payload is None and task.dify_dsl:
             dsl_payload = yaml.safe_load(task.dify_dsl)
@@ -91,7 +92,9 @@ class ConversionService:
             "source_workflow_name": task.source_workflow_name,
             "dsl": dsl_payload or {},
             "report": task.report or {},
-            "write_result": snapshot.get("write_result"),
+            "write_result": self._serialize_write_result(snapshot.get("write_result")),
+            "audit": self._serialize_audit(snapshot.get("audit"), task),
+            "error_message": task.error_message,
             "created_at": task.created_at.isoformat() if task.created_at else None,
             "completed_at": task.completed_at.isoformat() if task.completed_at else None,
         }
@@ -126,7 +129,7 @@ class ConversionService:
         if not target_db_url:
             raise ValueError("Dify database URL is required")
 
-        snapshot = task.ir_snapshot or {}
+        snapshot = dict(task.ir_snapshot or {})
         dsl_payload = snapshot.get("dify_dsl")
         if dsl_payload is None:
             if not task.dify_dsl:
@@ -135,23 +138,55 @@ class ConversionService:
 
         dify_dsl = DifyDSL.model_validate(dsl_payload)
         writer = DifyDbWriter(target_db_url)
-        if app_id:
-            writer.update_workflow(app_id, dify_dsl)
-            mode = "update"
-            target_app_id = app_id
-        else:
-            target_app_id = writer.write_workflow(dify_dsl)
-            mode = "create"
+        write_started_at = datetime.now(timezone.utc)
+        audit = self._serialize_audit(snapshot.get("audit"), task)
 
-        snapshot["write_result"] = {
-            "app_id": target_app_id,
-            "mode": mode,
-            "db_url": target_db_url,
-            "written_at": datetime.now(timezone.utc).isoformat(),
-        }
+        try:
+            if app_id:
+                writer.update_workflow(app_id, dify_dsl)
+                mode = "update"
+                target_app_id = app_id
+            else:
+                target_app_id = writer.write_workflow(dify_dsl)
+                mode = "create"
+        except Exception as exc:  # noqa: BLE001 - persist sanitized write failure details
+            sanitized_error = sanitize_exception(exc, db_urls=[target_db_url])
+            write_result = self._build_write_result(
+                mode="update" if app_id else "create",
+                app_id=app_id,
+                target_db_url=target_db_url,
+                written_at=write_started_at,
+                status="failed",
+                error=sanitized_error,
+                requested_app_id=app_id,
+            )
+            audit["last_write"] = write_result
+            snapshot["audit"] = audit
+            snapshot["write_result"] = write_result
+            task.ir_snapshot = snapshot
+            task.error_message = sanitized_error
+            task.status = "write_failed"
+            task.completed_at = write_started_at.replace(tzinfo=None)
+            db.add(task)
+            db.commit()
+            db.refresh(task)
+            raise RuntimeError(sanitized_error) from exc
+
+        write_result = self._build_write_result(
+            mode=mode,
+            app_id=target_app_id,
+            target_db_url=target_db_url,
+            written_at=write_started_at,
+            status="succeeded",
+            requested_app_id=app_id,
+        )
+        audit["last_write"] = write_result
+        snapshot["audit"] = audit
+        snapshot["write_result"] = write_result
         task.ir_snapshot = snapshot
+        task.error_message = None
         task.status = "updated" if mode == "update" else "written"
-        task.completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        task.completed_at = write_started_at.replace(tzinfo=None)
         db.add(task)
         db.commit()
         db.refresh(task)
@@ -161,6 +196,7 @@ class ConversionService:
             "app_id": target_app_id,
             "mode": mode,
             "status": task.status,
+            "write_result": write_result,
         }
 
     def _store_conversion(
@@ -178,6 +214,14 @@ class ConversionService:
             "ir_workflow": ir_workflow.model_dump(mode="json"),
             "dify_dsl": dify_dsl.model_dump(mode="json"),
             "write_result": None,
+            "audit": {
+                "source": {
+                    "type": source_type,
+                    "workflow_id": source_workflow_id,
+                    "workflow_name": source_workflow_name,
+                },
+                "last_write": None,
+            },
         }
         task = MigrationTask(
             source_type=source_type,
@@ -221,7 +265,9 @@ class ConversionService:
             "source_workflow_name": task.source_workflow_name,
             "created_at": task.created_at.isoformat() if task.created_at else None,
             "completed_at": task.completed_at.isoformat() if task.completed_at else None,
-            "write_result": write_result,
+            "write_result": cls._serialize_write_result(write_result),
+            "audit": cls._serialize_audit(snapshot.get("audit"), task),
+            "error_message": task.error_message,
             "report_summary": cls._build_report_summary(task.report),
         }
 
@@ -242,6 +288,65 @@ class ConversionService:
             "warnings_count": len(warnings) if isinstance(warnings, list) else 0,
             "errors_count": len(errors) if isinstance(errors, list) else 0,
         }
+
+    @staticmethod
+    def _build_write_result(
+        *,
+        mode: str,
+        app_id: str | None,
+        target_db_url: str,
+        written_at: datetime,
+        status: str,
+        error: str | None = None,
+        requested_app_id: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "app_id": app_id,
+            "mode": mode,
+            "status": status,
+            "error": error,
+            "requested_app_id": requested_app_id,
+            "target": build_database_ref(target_db_url),
+            "written_at": written_at.isoformat(),
+        }
+
+    @staticmethod
+    def _serialize_write_result(write_result: Any) -> dict[str, Any] | None:
+        if not isinstance(write_result, dict):
+            return None
+
+        target = write_result.get("target")
+        if not isinstance(target, dict):
+            target = build_database_ref(write_result.get("db_url"))
+
+        return {
+            "app_id": write_result.get("app_id"),
+            "mode": write_result.get("mode"),
+            "status": write_result.get("status") or ("failed" if write_result.get("error") else "succeeded"),
+            "error": write_result.get("error"),
+            "requested_app_id": write_result.get("requested_app_id"),
+            "target": target,
+            "written_at": write_result.get("written_at"),
+        }
+
+    @classmethod
+    def _serialize_audit(cls, audit: Any, task: MigrationTask) -> dict[str, Any]:
+        payload = dict(audit) if isinstance(audit, dict) else {}
+        source = payload.get("source")
+        if not isinstance(source, dict):
+            source = {}
+
+        payload["source"] = {
+            "type": source.get("type") or task.source_type,
+            "workflow_id": source.get("workflow_id") or task.source_workflow_id,
+            "workflow_name": source.get("workflow_name") or task.source_workflow_name,
+        }
+
+        payload["last_write"] = cls._serialize_write_result(payload.get("last_write"))
+        if payload["last_write"] is None and isinstance(task.ir_snapshot, dict):
+            payload["last_write"] = cls._serialize_write_result(task.ir_snapshot.get("write_result"))
+
+        return payload
 
     @classmethod
     def _extract_canvas(cls, payload: Any) -> dict[str, Any]:

--- a/backend/core/security/redaction.py
+++ b/backend/core/security/redaction.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+from urllib.parse import urlsplit
+
+
+_DB_URL_RE = re.compile(
+    r"(?P<url>(?:postgres(?:ql)?|mysql|mariadb|sqlite|oracle|mssql(?:\+pyodbc)?):\/\/[^\s'\"<>]+)",
+    re.IGNORECASE,
+)
+
+
+def build_database_ref(db_url: str | None) -> dict[str, str | int | None] | None:
+    if not db_url:
+        return None
+
+    value = str(db_url).strip()
+    if not value:
+        return None
+
+    parts = urlsplit(value)
+    scheme = parts.scheme or None
+    host = parts.hostname or None
+    port = parts.port
+    database = parts.path.lstrip("/") or None
+
+    if scheme == "sqlite":
+        database = database or parts.netloc or None
+        display_url = "sqlite:///***"
+        if database:
+            display_url = f"sqlite:///***/{database.split('/')[-1]}"
+        return {
+            "scheme": scheme,
+            "host": None,
+            "port": None,
+            "database": database,
+            "display_url": display_url,
+        }
+
+    location = host or parts.netloc.rsplit("@", 1)[-1] or "***"
+    if host and port:
+        location = f"{host}:{port}"
+
+    display_url = value
+    if scheme:
+        display_url = f"{scheme}://***@{location}"
+    elif location:
+        display_url = f"***@{location}"
+
+    if database:
+        display_url = f"{display_url}/{database}"
+
+    return {
+        "scheme": scheme,
+        "host": host or None,
+        "port": port,
+        "database": database,
+        "display_url": display_url,
+    }
+
+
+def redact_database_url(db_url: str | None) -> str | None:
+    ref = build_database_ref(db_url)
+    if ref is None:
+        return None
+    return str(ref["display_url"])
+
+
+def sanitize_error_message(
+    message: str,
+    *,
+    db_urls: Iterable[str] = (),
+    secrets: Iterable[str] = (),
+) -> str:
+    sanitized = message
+
+    for secret in secrets:
+        value = (secret or "").strip()
+        if value:
+            sanitized = sanitized.replace(value, "[REDACTED]")
+
+    for db_url in db_urls:
+        value = (db_url or "").strip()
+        if not value:
+            continue
+        sanitized = sanitized.replace(value, redact_database_url(value) or "[REDACTED]")
+
+    return _DB_URL_RE.sub(lambda match: redact_database_url(match.group("url")) or "[REDACTED]", sanitized)
+
+
+def sanitize_exception(
+    exc: Exception,
+    *,
+    db_urls: Iterable[str] = (),
+    secrets: Iterable[str] = (),
+) -> str:
+    return sanitize_error_message(str(exc), db_urls=db_urls, secrets=secrets)

--- a/backend/core/sync/sync_engine.py
+++ b/backend/core/sync/sync_engine.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from core.coze.db_reader import CozeDbReader
 from core.dify.db_reader import DifyDbReader
 from core.engine.conversion_service import ConversionService
+from core.security.redaction import build_database_ref, sanitize_exception
 from core.sync.conflict_resolver import ConflictResolver, ConflictStrategy
 from core.sync.diff_detector import DiffDetector
 from db.models import MigrationTask, SyncConfig, SyncHistory
@@ -58,6 +59,7 @@ class SyncEngine:
         summary = self._empty_summary()
         items: list[dict[str, Any]] = []
         status = "completed"
+        audit = self._build_history_audit(config, trigger_type)
 
         try:
             source_workflows = self.coze_reader_factory(config.coze_db_url).list_workflows()
@@ -183,6 +185,7 @@ class SyncEngine:
                         )
                     )
                 except Exception as exc:  # noqa: BLE001 - preserve run history instead of failing the whole request
+                    sanitized_error = self._sanitize_sync_error(exc, config)
                     items.append(
                         self._result_item(
                             action=action,
@@ -190,18 +193,19 @@ class SyncEngine:
                             source_workflow_id=source_id,
                             source_workflow_name=source_name,
                             target_app_id=mapping["app_id"] if mapping else None,
-                            message=str(exc),
+                            message=sanitized_error,
                         )
                     )
                     summary["failed"] += 1
         except Exception as exc:  # noqa: BLE001 - persist run-level failure details
+            sanitized_error = self._sanitize_sync_error(exc, config)
             items.append(
                 self._result_item(
                     action="inspect",
                     status="failed",
                     source_workflow_id="",
                     source_workflow_name=config.name,
-                    message=str(exc),
+                    message=sanitized_error,
                 )
             )
             summary["failed"] += 1
@@ -213,8 +217,13 @@ class SyncEngine:
         history.workflows_synced = summary["created"] + summary["updated"]
         history.workflows_failed = summary["failed"]
         history.conflicts_count = summary["conflicts"]
-        history.conflicts_resolved = {"summary": summary, "items": items}
         history.completed_at = _utcnow()
+        history.conflicts_resolved = self._build_history_payload(
+            audit=audit,
+            summary=summary,
+            items=items,
+            completed_at=history.completed_at,
+        )
         history.status = status
         db.add(history)
         db.commit()
@@ -303,7 +312,7 @@ class SyncEngine:
                         source_workflow_id=source_id,
                         source_workflow_name=source_name,
                         target_app_id=mapping["app_id"] if mapping else None,
-                        message=str(exc),
+                        message=self._sanitize_sync_error(exc, config),
                     )
                 )
                 summary["failed"] += 1
@@ -404,6 +413,7 @@ class SyncEngine:
         config = history.sync_config
         if config is None:
             raise LookupError(f"Sync config {history.sync_config_id} not found")
+        audit = self._coerce_history_audit(payload.get("audit"), config, history.trigger_type)
 
         index = next(
             (
@@ -440,7 +450,18 @@ class SyncEngine:
                 "status": "pending_manual_review",
             }
             items[index] = conflict_item
-            history.conflicts_resolved = {"summary": summary, "items": items}
+            audit["last_resolution"] = {
+                "conflict_id": conflict_id,
+                "strategy": strategy.value,
+                "status": "pending_manual_review",
+                "resolved_at": conflict_item["resolution"]["resolved_at"],
+            }
+            history.conflicts_resolved = self._build_history_payload(
+                audit=audit,
+                summary=summary,
+                items=items,
+                completed_at=history.completed_at,
+            )
             db.add(history)
             db.commit()
             db.refresh(history)
@@ -492,10 +513,21 @@ class SyncEngine:
             )
 
         items[index] = conflict_item
+        audit["last_resolution"] = {
+            "conflict_id": conflict_id,
+            "strategy": strategy.value,
+            "status": conflict_item["resolution"]["status"],
+            "resolved_at": conflict_item["resolution"]["resolved_at"],
+        }
         history.workflows_failed = summary["failed"]
         history.conflicts_count = summary["conflicts"]
-        history.conflicts_resolved = {"summary": summary, "items": items}
         history.completed_at = _utcnow()
+        history.conflicts_resolved = self._build_history_payload(
+            audit=audit,
+            summary=summary,
+            items=items,
+            completed_at=history.completed_at,
+        )
         history.status = self._derive_status(summary)
         db.add(history)
         db.commit()
@@ -521,10 +553,77 @@ class SyncEngine:
                 **SyncEngine._empty_summary(),
                 **summary,
             },
+            "audit": payload.get("audit") or None,
         }
         if include_items:
             data["items"] = payload.get("items") or []
         return data
+
+    @staticmethod
+    def _build_history_audit(config: SyncConfig, trigger_type: str) -> dict[str, Any]:
+        return {
+            "config_name": config.name,
+            "sync_mode": config.sync_mode,
+            "cron_expression": config.cron_expression,
+            "trigger_type": trigger_type,
+            "source_db": build_database_ref(config.coze_db_url),
+            "target_db": build_database_ref(config.dify_db_url),
+        }
+
+    @classmethod
+    def _coerce_history_audit(
+        cls,
+        audit: Any,
+        config: SyncConfig,
+        trigger_type: str,
+    ) -> dict[str, Any]:
+        payload = dict(audit) if isinstance(audit, dict) else {}
+        payload.setdefault("config_name", config.name)
+        payload.setdefault("sync_mode", config.sync_mode)
+        payload.setdefault("cron_expression", config.cron_expression)
+        payload.setdefault("trigger_type", trigger_type)
+        payload.setdefault("source_db", build_database_ref(config.coze_db_url))
+        payload.setdefault("target_db", build_database_ref(config.dify_db_url))
+        return payload
+
+    @classmethod
+    def _build_history_payload(
+        cls,
+        *,
+        audit: dict[str, Any],
+        summary: dict[str, int],
+        items: list[dict[str, Any]],
+        completed_at: datetime | None,
+    ) -> dict[str, Any]:
+        failure_samples = cls._collect_failure_samples(items)
+        audit_payload = {
+            **audit,
+            "failure_samples": failure_samples,
+            "last_error": failure_samples[0] if failure_samples else None,
+            "completed_at": completed_at.isoformat() if completed_at else None,
+        }
+        return {
+            "summary": summary,
+            "items": items,
+            "audit": audit_payload,
+        }
+
+    @staticmethod
+    def _collect_failure_samples(items: list[dict[str, Any]]) -> list[str]:
+        samples: list[str] = []
+        for item in items:
+            if item.get("status") != "failed":
+                continue
+            message = str(item.get("message") or "").strip()
+            if message and message not in samples:
+                samples.append(message)
+            if len(samples) >= 3:
+                break
+        return samples
+
+    @staticmethod
+    def _sanitize_sync_error(exc: Exception, config: SyncConfig) -> str:
+        return sanitize_exception(exc, db_urls=[config.coze_db_url, config.dify_db_url])
 
     @staticmethod
     def _empty_summary() -> dict[str, int]:
@@ -588,7 +687,18 @@ class SyncEngine:
         task = db.get(MigrationTask, int(conversion_id))
         if task is None:
             return
+        config = db.get(SyncConfig, sync_config_id)
+        snapshot = dict(task.ir_snapshot or {})
+        audit = snapshot.get("audit") if isinstance(snapshot, dict) else None
+        if not isinstance(audit, dict):
+            audit = {}
+        audit["sync"] = {
+            "sync_config_id": sync_config_id,
+            "sync_config_name": config.name if config else None,
+        }
+        snapshot["audit"] = audit
         task.sync_config_id = sync_config_id
+        task.ir_snapshot = snapshot
         db.add(task)
         db.commit()
 

--- a/backend/tests/test_conversion_service.py
+++ b/backend/tests/test_conversion_service.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -120,6 +121,85 @@ def test_list_conversions_returns_paginated_history_without_sync_tasks(tmp_path)
     assert [item["conversion_id"] for item in first_page["items"]] == [second["conversion_id"]]
     assert first_page["items"][0]["status"] == "written"
     assert first_page["items"][0]["write_result"]["app_id"] == "app-history-123"
+    assert first_page["items"][0]["write_result"]["target"]["display_url"] == "postgresql://***@dify.example/db"
     assert first_page["items"][0]["report_summary"]["total_nodes"] == 2
     assert first_page["items"][0]["report_summary"]["mapped_count"] >= 0
     assert [item["conversion_id"] for item in second_page["items"]] == [first["conversion_id"]]
+
+
+def test_write_to_dify_persists_redacted_write_audit(tmp_path, monkeypatch) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-write-success.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    service = ConversionService()
+
+    class SuccessfulWriter:
+        def __init__(self, db_url: str) -> None:
+            self.db_url = db_url
+
+        def write_workflow(self, dify_dsl) -> str:  # noqa: ANN001 - test double
+            return "app-created-123"
+
+    monkeypatch.setattr("core.engine.conversion_service.DifyDbWriter", SuccessfulWriter)
+
+    with session_factory() as db:
+        conversion = service.convert_uploaded_file(
+            db,
+            json.dumps(MINIMAL_COZE_CANVAS).encode(),
+            "write-success.json",
+        )
+        write_result = service.write_to_dify(
+            db,
+            conversion["conversion_id"],
+            db_url="postgresql://writer:supersecret@dify.example:5432/dify",
+        )
+        persisted = service.get_conversion(db, conversion["conversion_id"])
+
+    assert write_result["status"] == "written"
+    assert write_result["write_result"]["target"]["display_url"] == "postgresql://***@dify.example:5432/dify"
+    assert write_result["write_result"]["status"] == "succeeded"
+    assert persisted["audit"]["last_write"]["app_id"] == "app-created-123"
+    assert persisted["error_message"] is None
+
+
+def test_write_to_dify_persists_sanitized_failure_details(tmp_path, monkeypatch) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-write-failure.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    service = ConversionService()
+
+    class FailingWriter:
+        def __init__(self, db_url: str) -> None:
+            self.db_url = db_url
+
+        def write_workflow(self, dify_dsl) -> str:  # noqa: ANN001 - test double
+            raise RuntimeError(f"unable to connect to {self.db_url}")
+
+    monkeypatch.setattr("core.engine.conversion_service.DifyDbWriter", FailingWriter)
+
+    with session_factory() as db:
+        conversion = service.convert_uploaded_file(
+            db,
+            json.dumps(MINIMAL_COZE_CANVAS).encode(),
+            "write-failure.json",
+        )
+
+        with pytest.raises(RuntimeError, match=r"postgresql://\*\*\*@dify.example:5432/dify"):
+            service.write_to_dify(
+                db,
+                conversion["conversion_id"],
+                db_url="postgresql://writer:supersecret@dify.example:5432/dify",
+            )
+
+        persisted = service.get_conversion(db, conversion["conversion_id"])
+
+    assert persisted["status"] == "write_failed"
+    assert persisted["error_message"] == "unable to connect to postgresql://***@dify.example:5432/dify"
+    assert persisted["write_result"]["status"] == "failed"
+    assert persisted["write_result"]["target"]["display_url"] == "postgresql://***@dify.example:5432/dify"

--- a/backend/tests/test_sync_api.py
+++ b/backend/tests/test_sync_api.py
@@ -23,6 +23,9 @@ class FakeCozeReader:
     def __init__(self, db_url: str) -> None:
         self.db_url = db_url
 
+    def test_connection(self) -> bool:
+        return True
+
     def list_workflows(self) -> list[dict[str, str]]:
         return [{"id": "wf-api", "name": "API Flow"}]
 
@@ -30,6 +33,9 @@ class FakeCozeReader:
 class FakeDifyReader:
     def __init__(self, db_url: str) -> None:
         self.db_url = db_url
+
+    def test_connection(self) -> bool:
+        return True
 
     def list_apps(self) -> list[dict[str, str]]:
         return []
@@ -79,7 +85,22 @@ class FakeConversionService:
         snapshot["write_result"] = {
             "app_id": app_id or "created-app",
             "mode": "update" if app_id else "create",
-            "db_url": db_url,
+            "status": "succeeded",
+            "target": {
+                "scheme": "postgresql",
+                "host": "dify.test",
+                "port": None,
+                "database": "app",
+                "display_url": "postgresql://***@dify.test/app",
+            },
+        }
+        snapshot["audit"] = {
+            "source": {
+                "type": "database",
+                "workflow_id": task.source_workflow_id,
+                "workflow_name": task.source_workflow_name,
+            },
+            "last_write": snapshot["write_result"],
         }
         task.ir_snapshot = snapshot
         task.status = "updated" if app_id else "written"
@@ -120,6 +141,8 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
             dify_reader_factory=FakeDifyReader,
         ),
     )
+    monkeypatch.setattr(sync_endpoints, "CozeDbReader", FakeCozeReader)
+    monkeypatch.setattr(sync_endpoints, "DifyDbReader", FakeDifyReader)
 
     client = TestClient(app)
     payload = {
@@ -156,7 +179,23 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
 
     config_response = client.get("/api/v1/sync/config")
     assert config_response.status_code == 200
-    assert config_response.json()["config"]["coze_db_url"] == payload["coze_db_url"]
+    config_payload = config_response.json()["config"]
+    assert config_payload["coze_db"]["display_url"] == "postgresql://***@coze.test/app"
+    assert config_payload["dify_db"]["display_url"] == "postgresql://***@dify.test/app"
+    assert config_payload["has_stored_coze_db_url"] is True
+    assert config_payload["has_stored_dify_db_url"] is True
+
+    test_response = client.post(
+        "/api/v1/sync/config/test",
+        json={
+            "config_id": config_payload["id"],
+            "name": "Manual Sync",
+            "coze_db_url": "",
+            "dify_db_url": "",
+        },
+    )
+    assert test_response.status_code == 200
+    assert test_response.json()["coze_db"]["connected"] is True
 
     with session_factory() as db:
         histories = db.execute(select(SyncHistory)).scalars().all()
@@ -164,6 +203,8 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
 
     assert len(histories) == 1
     assert histories[0].workflows_synced == 1
+    assert histories[0].conflicts_resolved["audit"]["source_db"]["display_url"] == "postgresql://***@coze.test/app"
+    assert histories[0].conflicts_resolved["audit"]["target_db"]["display_url"] == "postgresql://***@dify.test/app"
     assert len(tasks) == 1
     assert tasks[0].sync_config_id == histories[0].sync_config_id
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,6 +143,12 @@ Get detailed conversion report (mapping stats, warnings, unmappable nodes).
 
 Direct-write conversion result to Dify PostgreSQL.
 
+Safety behavior:
+
+- raw target DB URLs are not echoed back in API-visible payloads
+- successful and failed writes persist redacted target references plus last-write audit metadata
+- write failures return actionable, sanitized error details
+
 ---
 
 ## Sync
@@ -154,6 +160,11 @@ Create or update sync configuration (source DB + target DB connection info).
 ### `GET /sync/config`
 
 Get current sync configuration.
+
+Safety behavior:
+
+- stored source/target DB URLs are returned as redacted references such as `postgresql://***@host/db`
+- blank DB URL fields on follow-up save/run requests keep the persisted value for the referenced `config_id`
 
 ### `POST /sync/config/test`
 
@@ -171,9 +182,17 @@ Get current sync status.
 
 List sync history records.
 
+Response includes persisted audit metadata with redacted source/target DB references plus recent failure samples when present.
+
 ### `GET /sync/history/{id}`
 
 Get detailed report for a specific sync run.
+
+Detailed payloads include:
+
+- redacted source and target DB references
+- latest resolution metadata for conflict handling
+- sanitized failure details suitable for operator troubleshooting
 
 ### `POST /sync/schedule`
 

--- a/frontend/src/api/conversion.ts
+++ b/frontend/src/api/conversion.ts
@@ -1,5 +1,5 @@
 import client from "./client";
-import type { ConversionDetail, ConversionHistoryResponse, ConversionResult } from "../types/ir";
+import type { ConversionDetail, ConversionHistoryResponse, ConversionResult, WriteResult } from "../types/ir";
 
 export async function convertWorkflow(file: File): Promise<ConversionResult> {
   const form = new FormData();
@@ -51,7 +51,7 @@ export async function getReport(conversionId: string) {
 export async function writeToDify(
   conversionId: string,
   payload: { db_url?: string; app_id?: string },
-): Promise<{ conversion_id: string; app_id: string; mode: "create" | "update"; status: string }> {
+): Promise<{ conversion_id: string; app_id: string | null; mode: "create" | "update"; status: string; write_result: WriteResult }> {
   const resp = await client.post(`/convert/${conversionId}/write-to-dify`, payload);
   return resp.data;
 }

--- a/frontend/src/components/history/ConversionHistoryTable.tsx
+++ b/frontend/src/components/history/ConversionHistoryTable.tsx
@@ -24,7 +24,7 @@ function getStatusTone(status: string): "mapped" | "partial" | "unmappable" | "s
   if (status === "converted" || status === "written" || status === "updated") {
     return "mapped";
   }
-  if (status === "failed" || status === "error") {
+  if (status === "failed" || status === "error" || status === "write_failed") {
     return "unmappable";
   }
   if (status === "skipped") {
@@ -101,7 +101,11 @@ export default function ConversionHistoryTable({ items }: { items: ConversionHis
                   <div style={{ display: "grid", gap: 6 }}>
                     <span className={`badge badge--${getStatusTone(item.status)}`}>{item.status}</span>
                     <span style={{ fontSize: "0.76rem", color: "var(--c-text-tertiary)" }}>
-                      {writeResult?.app_id ? `${writeResult.mode === "update" ? "Updated" : "Created"} app` : "Ready for review"}
+                      {item.error_message
+                        ? item.error_message
+                        : writeResult?.app_id
+                          ? `${writeResult.mode === "update" ? "Updated" : "Created"} app`
+                          : "Ready for review"}
                     </span>
                   </div>
                 </td>
@@ -141,6 +145,11 @@ export default function ConversionHistoryTable({ items }: { items: ConversionHis
                       <span style={{ fontSize: "0.74rem", color: "var(--c-text-tertiary)" }}>
                         {formatTimestamp(writeResult.written_at || item.completed_at)}
                       </span>
+                      {writeResult.target?.display_url ? (
+                        <span style={{ fontSize: "0.72rem", color: "var(--c-text-tertiary)", fontFamily: "var(--font-mono)" }}>
+                          {writeResult.target.display_url}
+                        </span>
+                      ) : null}
                       {difyAppUrl ? (
                         <a
                           href={difyAppUrl}
@@ -150,6 +159,15 @@ export default function ConversionHistoryTable({ items }: { items: ConversionHis
                         >
                           Open in Dify
                         </a>
+                      ) : null}
+                    </div>
+                  ) : item.error_message ? (
+                    <div style={{ display: "grid", gap: 4 }}>
+                      <span style={{ color: "var(--c-red)", fontSize: "0.78rem" }}>{item.error_message}</span>
+                      {item.audit?.last_write?.target?.display_url ? (
+                        <span style={{ fontSize: "0.72rem", color: "var(--c-text-tertiary)", fontFamily: "var(--font-mono)" }}>
+                          {item.audit.last_write.target.display_url}
+                        </span>
                       ) : null}
                     </div>
                   ) : (

--- a/frontend/src/components/result/DirectWriteButton.tsx
+++ b/frontend/src/components/result/DirectWriteButton.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { writeToDify } from "../../api/conversion";
 import { usePlatformStore } from "../../store/platformStore";
+import type { WriteResult } from "../../types/ir";
 
 export default function DirectWriteButton({ conversionId }: { conversionId: string }) {
   const { difyDbUrl, difyApiBase, difySelectedAppId } = usePlatformStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [result, setResult] = useState<{ appId: string; mode: "create" | "update" } | null>(null);
+  const [result, setResult] = useState<WriteResult | null>(null);
 
   const handleWrite = async () => {
     setLoading(true);
@@ -16,7 +17,7 @@ export default function DirectWriteButton({ conversionId }: { conversionId: stri
         db_url: difyDbUrl || undefined,
         app_id: difySelectedAppId || undefined,
       });
-      setResult({ appId: response.app_id, mode: response.mode });
+      setResult(response.write_result);
     } catch (e: any) {
       setError(e?.response?.data?.detail || e?.message || "Write to Dify failed");
     } finally {
@@ -24,7 +25,8 @@ export default function DirectWriteButton({ conversionId }: { conversionId: stri
     }
   };
 
-  const difyAppUrl = result && difyApiBase ? `${difyApiBase.replace(/\/$/, "")}/app/${result.appId}/workflow` : null;
+  const difyAppUrl =
+    result?.app_id && difyApiBase ? `${difyApiBase.replace(/\/$/, "")}/app/${result.app_id}/workflow` : null;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 6 }}>
@@ -32,17 +34,26 @@ export default function DirectWriteButton({ conversionId }: { conversionId: stri
         {loading ? "Writing..." : difySelectedAppId ? "🗄 Update Dify App" : "🗄 Write to Dify DB"}
       </button>
       {result && (
-        <span style={{ fontSize: "0.72rem", color: "var(--c-green)" }}>
-          {result.mode === "update" ? "Updated" : "Created"} app {result.appId.slice(0, 12)}…
-          {difyAppUrl && (
-            <>
-              {" "}
-              <a href={difyAppUrl} target="_blank" rel="noreferrer">
-                Open
-              </a>
-            </>
+        <div style={{ display: "grid", gap: 2 }}>
+          <span style={{ fontSize: "0.72rem", color: result.status === "failed" ? "var(--c-red)" : "var(--c-green)" }}>
+            {result.status === "failed"
+              ? result.error || "Write failed"
+              : `${result.mode === "update" ? "Updated" : "Created"} app ${(result.app_id || "unknown").slice(0, 12)}…`}
+            {difyAppUrl && (
+              <>
+                {" "}
+                <a href={difyAppUrl} target="_blank" rel="noreferrer">
+                  Open
+                </a>
+              </>
+            )}
+          </span>
+          {result.target?.display_url && (
+            <span style={{ fontSize: "0.68rem", color: "var(--c-text-tertiary)", fontFamily: "var(--font-mono)" }}>
+              {result.target.display_url}
+            </span>
           )}
-        </span>
+        </div>
       )}
       {error && (
         <span style={{ fontSize: "0.72rem", color: "var(--c-red)" }}>{error}</span>

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -123,6 +123,30 @@ export default function SyncHistoryPage() {
                   tone="var(--c-red)"
                 />
               </div>
+
+              {selectedRun.audit ? (
+                <div style={{ display: "grid", gap: 8, marginTop: 18 }}>
+                  {selectedRun.audit.source_db?.display_url ? (
+                    <div style={{ fontSize: "0.8rem", color: "var(--c-text-tertiary)" }}>
+                      Source DB:{" "}
+                      <span style={{ fontFamily: "var(--font-mono)" }}>
+                        {selectedRun.audit.source_db.display_url}
+                      </span>
+                    </div>
+                  ) : null}
+                  {selectedRun.audit.target_db?.display_url ? (
+                    <div style={{ fontSize: "0.8rem", color: "var(--c-text-tertiary)" }}>
+                      Target DB:{" "}
+                      <span style={{ fontFamily: "var(--font-mono)" }}>
+                        {selectedRun.audit.target_db.display_url}
+                      </span>
+                    </div>
+                  ) : null}
+                  {selectedRun.audit.last_error ? (
+                    <div className="alert alert--error">{selectedRun.audit.last_error}</div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
         </>

--- a/frontend/src/pages/SyncPage.tsx
+++ b/frontend/src/pages/SyncPage.tsx
@@ -46,6 +46,7 @@ const EMPTY_SUMMARY: SyncSummary = {
 
 export default function SyncPage() {
   const [form, setForm] = useState<SyncConfigInput>(DEFAULT_FORM);
+  const [storedConfig, setStoredConfig] = useState<SyncConfig | null>(null);
   const [history, setHistory] = useState<SyncHistoryEntry[]>([]);
   const [selectedRun, setSelectedRun] = useState<SyncRunDetail | null>(null);
   const [diffPreview, setDiffPreview] = useState<SyncDiffPreview | null>(null);
@@ -78,7 +79,9 @@ export default function SyncPage() {
 
       setSyncStatus(status);
       if (config) {
-        setForm(toInput(config));
+        applyStoredConfig(config);
+      } else {
+        setStoredConfig(null);
       }
 
       setHistory(historyItems);
@@ -101,6 +104,17 @@ export default function SyncPage() {
     return status;
   };
 
+  const refreshConfig = async () => {
+    const config = await getSyncConfig();
+    if (config) {
+      applyStoredConfig(config);
+    } else {
+      setStoredConfig(null);
+      setForm(DEFAULT_FORM);
+    }
+    return config;
+  };
+
   const refreshHistory = async (selectedId?: string) => {
     const items = await listSyncHistory();
     setHistory(items);
@@ -118,6 +132,11 @@ export default function SyncPage() {
     setForm((current) => ({ ...current, [field]: value }));
   };
 
+  const applyStoredConfig = (config: SyncConfig) => {
+    setStoredConfig(config);
+    setForm(toInput(config));
+  };
+
   const handleSave = async () => {
     setSaving(true);
     setError("");
@@ -128,7 +147,7 @@ export default function SyncPage() {
         sync_mode: "manual",
         cron_expression: null,
       });
-      setForm(toInput(saved));
+      applyStoredConfig(saved);
       setDiffPreview(null);
       await refreshStatus();
       setInfo("Manual sync config saved.");
@@ -161,11 +180,7 @@ export default function SyncPage() {
     try {
       const preview = await previewSyncDiff(form);
       setDiffPreview(preview);
-      setForm((current) => ({
-        ...current,
-        config_id: preview.config_id,
-      }));
-      await refreshStatus();
+      await Promise.all([refreshStatus(), refreshConfig()]);
       setInfo("Sync diff preview updated.");
     } catch (e: any) {
       setError(e?.response?.data?.detail || e?.message || "Failed to preview sync diff");
@@ -180,13 +195,9 @@ export default function SyncPage() {
     setInfo("");
     try {
       const run = await executeManualSync(form);
-      setForm((current) => ({
-        ...current,
-        config_id: run.sync_config_id,
-      }));
       setDiffPreview(null);
       setSelectedRun(run);
-      await Promise.all([refreshHistory(run.id), refreshStatus()]);
+      await Promise.all([refreshHistory(run.id), refreshStatus(), refreshConfig()]);
       setInfo("Manual sync run completed.");
     } catch (e: any) {
       setError(e?.response?.data?.detail || e?.message || "Manual sync failed");
@@ -211,7 +222,7 @@ export default function SyncPage() {
         cron_expression: cronExpression,
         sync_mode: "scheduled",
       });
-      setForm(toInput(config));
+      applyStoredConfig(config);
       await refreshStatus();
       setInfo("Scheduled sync saved.");
     } catch (e: any) {
@@ -232,7 +243,7 @@ export default function SyncPage() {
     setInfo("");
     try {
       const { config, cancelled } = await cancelSyncSchedule(form.config_id);
-      setForm(toInput(config));
+      applyStoredConfig(config);
       await refreshStatus();
       setInfo(cancelled ? "Scheduled sync cancelled." : "No active schedule was registered for this config.");
     } catch (e: any) {
@@ -286,7 +297,9 @@ export default function SyncPage() {
     }
   };
 
-  const disabled = !form.coze_db_url.trim() || !form.dify_db_url.trim();
+  const hasCozeTarget = Boolean(form.coze_db_url.trim() || storedConfig?.has_stored_coze_db_url);
+  const hasDifyTarget = Boolean(form.dify_db_url.trim() || storedConfig?.has_stored_dify_db_url);
+  const disabled = !hasCozeTarget || !hasDifyTarget;
   const scheduledJobs = syncStatus?.scheduled_jobs || [];
   const currentSchedule = form.config_id
     ? scheduledJobs.find((job) => job.config_id === form.config_id) || null
@@ -330,8 +343,14 @@ export default function SyncPage() {
                 className="input input-mono"
                 value={form.coze_db_url}
                 onChange={(e) => updateField("coze_db_url", e.target.value)}
-                placeholder="postgresql://user:pass@host:5432/coze"
+                placeholder={storedConfig?.coze_db?.display_url || "postgresql://user:pass@host:5432/coze"}
               />
+              {storedConfig?.coze_db?.display_url ? (
+                <div style={{ marginTop: 6, fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+                  Stored source: <span style={{ fontFamily: "var(--font-mono)" }}>{storedConfig.coze_db.display_url}</span>
+                  {form.coze_db_url.trim() ? " (new value will replace it on save)" : " (leave blank to reuse it)"}
+                </div>
+              ) : null}
             </div>
 
             <div>
@@ -340,8 +359,14 @@ export default function SyncPage() {
                 className="input input-mono"
                 value={form.dify_db_url}
                 onChange={(e) => updateField("dify_db_url", e.target.value)}
-                placeholder="postgresql://user:pass@host:5432/dify"
+                placeholder={storedConfig?.dify_db?.display_url || "postgresql://user:pass@host:5432/dify"}
               />
+              {storedConfig?.dify_db?.display_url ? (
+                <div style={{ marginTop: 6, fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+                  Stored target: <span style={{ fontFamily: "var(--font-mono)" }}>{storedConfig.dify_db.display_url}</span>
+                  {form.dify_db_url.trim() ? " (new value will replace it on save)" : " (leave blank to reuse it)"}
+                </div>
+              ) : null}
             </div>
 
             <div>
@@ -459,9 +484,9 @@ export default function SyncPage() {
               <div style={{ marginTop: 20 }}>
                 <div className="section-title" style={{ fontSize: "0.95rem" }}>Selected Run Summary</div>
                 <p className="section-subtitle">
-                  {selectedRun
-                    ? `Run ${selectedRun.id} • ${formatTimestamp(selectedRun.started_at)}`
-                    : "No persisted sync run selected yet."}
+                {selectedRun
+                  ? `Run ${selectedRun.id} • ${formatTimestamp(selectedRun.started_at)}`
+                  : "No persisted sync run selected yet."}
                 </p>
 
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 12, marginTop: 16 }}>
@@ -478,6 +503,10 @@ export default function SyncPage() {
                     Status: <strong>{selectedRun.status}</strong>
                     {selectedRun.completed_at ? ` • Completed ${formatTimestamp(selectedRun.completed_at)}` : ""}
                   </div>
+                ) : null}
+
+                {selectedRun?.audit ? (
+                  <RunAuditPanel audit={selectedRun.audit} />
                 ) : null}
               </div>
             </>
@@ -550,8 +579,8 @@ function toInput(config: SyncConfig): SyncConfigInput {
     config_id: config.id,
     name: config.name,
     coze_db_type: config.coze_db_type,
-    coze_db_url: config.coze_db_url,
-    dify_db_url: config.dify_db_url,
+    coze_db_url: "",
+    dify_db_url: "",
     sync_mode: config.sync_mode,
     cron_expression: config.cron_expression || "",
   };
@@ -611,6 +640,40 @@ function ConnectionCard({
       <div style={{ marginTop: 4 }}>
         {result.connected ? "Connected" : result.error || "Connection failed"}
       </div>
+    </div>
+  );
+}
+
+function RunAuditPanel({ audit }: { audit: NonNullable<SyncRunDetail["audit"]> }) {
+  const failures = audit.failure_samples || [];
+
+  return (
+    <div style={{ display: "grid", gap: 10, marginTop: 16 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        {audit.source_db?.display_url ? (
+          <div style={{ fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+            Source DB: <span style={{ fontFamily: "var(--font-mono)" }}>{audit.source_db.display_url}</span>
+          </div>
+        ) : null}
+        {audit.target_db?.display_url ? (
+          <div style={{ fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+            Target DB: <span style={{ fontFamily: "var(--font-mono)" }}>{audit.target_db.display_url}</span>
+          </div>
+        ) : null}
+      </div>
+
+      {audit.last_error ? (
+        <div className="alert alert--error">
+          <strong>Last error</strong>
+          <div style={{ marginTop: 4 }}>{audit.last_error}</div>
+        </div>
+      ) : null}
+
+      {failures.length > 1 ? (
+        <div style={{ fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+          {failures.length} failure samples captured in the persisted audit trail.
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/types/audit.ts
+++ b/frontend/src/types/audit.ts
@@ -1,0 +1,7 @@
+export interface DatabaseTargetRef {
+  scheme: string | null;
+  host: string | null;
+  port: number | null;
+  database: string | null;
+  display_url: string;
+}

--- a/frontend/src/types/ir.ts
+++ b/frontend/src/types/ir.ts
@@ -1,3 +1,5 @@
+import type { DatabaseTargetRef } from "./audit";
+
 export type MappingStatus = "mapped" | "partial" | "unmappable" | "skipped";
 
 export interface NodeConversionResult {
@@ -41,10 +43,26 @@ export interface ConversionResult {
 }
 
 export interface WriteResult {
-  app_id: string;
+  app_id: string | null;
   mode: "create" | "update";
-  db_url?: string;
+  status: "succeeded" | "failed";
+  error?: string | null;
+  requested_app_id?: string | null;
+  target?: DatabaseTargetRef | null;
   written_at?: string;
+}
+
+export interface ConversionAudit {
+  source: {
+    type: string;
+    workflow_id: string;
+    workflow_name: string;
+  };
+  sync?: {
+    sync_config_id: number;
+    sync_config_name: string | null;
+  } | null;
+  last_write?: WriteResult | null;
 }
 
 export interface ConversionHistoryReportSummary {
@@ -67,6 +85,8 @@ export interface ConversionHistoryItem {
   created_at: string | null;
   completed_at: string | null;
   write_result: WriteResult | null;
+  audit: ConversionAudit | null;
+  error_message: string | null;
   report_summary: ConversionHistoryReportSummary | null;
 }
 
@@ -84,6 +104,8 @@ export interface ConversionDetail {
   dsl: Record<string, unknown>;
   report: ConversionReport;
   write_result: WriteResult | null;
+  audit: ConversionAudit | null;
+  error_message: string | null;
   created_at: string | null;
   completed_at: string | null;
 }

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -1,3 +1,5 @@
+import type { DatabaseTargetRef } from "./audit";
+
 export type SyncMode = "manual" | "scheduled";
 export type SyncRunStatus = "completed" | "partial" | "failed" | "running";
 export type SyncConflictStrategy = "source_wins" | "target_wins" | "manual";
@@ -6,8 +8,10 @@ export interface SyncConfig {
   id: number;
   name: string;
   coze_db_type: string;
-  coze_db_url: string;
-  dify_db_url: string;
+  coze_db: DatabaseTargetRef | null;
+  dify_db: DatabaseTargetRef | null;
+  has_stored_coze_db_url: boolean;
+  has_stored_dify_db_url: boolean;
   sync_mode: SyncMode;
   cron_expression: string | null;
   enabled: boolean;
@@ -78,6 +82,24 @@ export interface SyncStatus {
   scheduled_jobs: SyncScheduledJob[];
 }
 
+export interface SyncRunAudit {
+  config_name?: string;
+  sync_mode?: string;
+  cron_expression?: string | null;
+  trigger_type?: string;
+  source_db?: DatabaseTargetRef | null;
+  target_db?: DatabaseTargetRef | null;
+  failure_samples?: string[];
+  last_error?: string | null;
+  completed_at?: string | null;
+  last_resolution?: {
+    conflict_id: string;
+    strategy: SyncConflictStrategy;
+    status: string;
+    resolved_at: string;
+  } | null;
+}
+
 export interface SyncHistoryEntry {
   id: string;
   sync_config_id: number;
@@ -90,6 +112,7 @@ export interface SyncHistoryEntry {
   workflows_failed: number;
   conflicts_count: number;
   summary: SyncSummary;
+  audit?: SyncRunAudit | null;
 }
 
 export interface SyncRunDetail extends SyncHistoryEntry {


### PR DESCRIPTION
## Summary
- redact DB connection details across sync config, sync history, and direct-write payloads
- persist operator audit metadata for sync runs and direct-write attempts, including sanitized failure details
- surface the redacted audit data in the frontend and document the production safety boundaries

## Testing
- cd backend && ruff check .
- cd backend && ruff format --check .
- cd backend && pytest -q
- cd backend && python -c "from main import app; print('OK')"
- cd frontend && npm exec tsc -- --noEmit
- cd frontend && npm run build
- ./scripts/ci-local.sh

Closes #24
