### PR TITLE
Add visual workflow diff experience

### DIFF
--- a/backend/core/engine/conversion_service.py
+++ b/backend/core/engine/conversion_service.py
@@ -91,6 +91,8 @@ class ConversionService:
             "source_workflow_id": task.source_workflow_id,
             "source_workflow_name": task.source_workflow_name,
             "dsl": dsl_payload or {},
+            "source_graph": self._build_source_graph(snapshot),
+            "target_graph": self._build_target_graph(dsl_payload),
             "report": task.report or {},
             "write_result": self._serialize_write_result(snapshot.get("write_result")),
             "audit": self._serialize_audit(snapshot.get("audit"), task),
@@ -270,6 +272,104 @@ class ConversionService:
             "error_message": task.error_message,
             "report_summary": cls._build_report_summary(task.report),
         }
+
+    @classmethod
+    def _build_source_graph(cls, snapshot: dict[str, Any]) -> dict[str, Any] | None:
+        ir_workflow = snapshot.get("ir_workflow")
+        if not isinstance(ir_workflow, dict):
+            return None
+
+        nodes, child_edge_count = cls._flatten_ir_nodes(ir_workflow.get("nodes"))
+        top_level_edges = ir_workflow.get("edges")
+        edge_count = child_edge_count
+        if isinstance(top_level_edges, list):
+            edge_count += sum(1 for edge in top_level_edges if isinstance(edge, dict))
+
+        return {
+            "node_count": len(nodes),
+            "edge_count": edge_count,
+            "nodes": nodes,
+        }
+
+    @staticmethod
+    def _build_target_graph(dsl_payload: Any) -> dict[str, Any] | None:
+        if not isinstance(dsl_payload, dict):
+            return None
+
+        workflow = dsl_payload.get("workflow")
+        if not isinstance(workflow, dict):
+            return None
+
+        graph = workflow.get("graph")
+        if not isinstance(graph, dict):
+            return None
+
+        nodes_payload = graph.get("nodes")
+        nodes: list[dict[str, Any]] = []
+        if isinstance(nodes_payload, list):
+            for node in nodes_payload:
+                if not isinstance(node, dict):
+                    continue
+
+                data = node.get("data")
+                if not isinstance(data, dict):
+                    data = {}
+
+                nodes.append(
+                    {
+                        "id": str(node.get("id") or ""),
+                        "type": str(data.get("type") or node.get("type") or ""),
+                        "title": str(data.get("title") or node.get("id") or ""),
+                        "parent_id": str(node.get("parentId")) if node.get("parentId") else None,
+                    }
+                )
+
+        edge_count = 0
+        edges_payload = graph.get("edges")
+        if isinstance(edges_payload, list):
+            edge_count = sum(1 for edge in edges_payload if isinstance(edge, dict))
+
+        return {
+            "node_count": len(nodes),
+            "edge_count": edge_count,
+            "nodes": nodes,
+        }
+
+    @classmethod
+    def _flatten_ir_nodes(
+        cls,
+        nodes_payload: Any,
+        *,
+        parent_id: str | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        if not isinstance(nodes_payload, list):
+            return [], 0
+
+        nodes: list[dict[str, Any]] = []
+        edge_count = 0
+        for node in nodes_payload:
+            if not isinstance(node, dict):
+                continue
+
+            node_id = str(node.get("id") or "")
+            nodes.append(
+                {
+                    "id": node_id,
+                    "type": str(node.get("node_type") or node.get("type") or ""),
+                    "title": str(node.get("title") or node_id or ""),
+                    "parent_id": parent_id,
+                }
+            )
+
+            child_edges = node.get("child_edges")
+            if isinstance(child_edges, list):
+                edge_count += sum(1 for edge in child_edges if isinstance(edge, dict))
+
+            child_nodes, child_edge_count = cls._flatten_ir_nodes(node.get("children"), parent_id=node_id or parent_id)
+            nodes.extend(child_nodes)
+            edge_count += child_edge_count
+
+        return nodes, edge_count
 
     @staticmethod
     def _build_report_summary(report: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/backend/tests/test_conversion_service.py
+++ b/backend/tests/test_conversion_service.py
@@ -5,6 +5,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.engine.conversion_service import ConversionService
+from core.ir.models import IREdge, IRNode, IRPosition, IRVariable, IRWorkflow
+from core.ir.types import IRNodeType, IRVariableType
 from db.database import Base
 from db.models import MigrationTask, SyncConfig
 
@@ -57,7 +59,76 @@ def test_convert_uploaded_file_persists_artifacts(tmp_path) -> None:
     assert persisted["source_workflow_name"] == "workflow.json"
     assert persisted["dsl"]["workflow"]["graph"]["nodes"]
     assert persisted["dsl"]["workflow"]["graph"]["edges"]
+    assert result["source_graph"]["node_count"] == 2
+    assert result["source_graph"]["edge_count"] == 1
+    assert result["target_graph"]["node_count"] == 2
+    assert result["target_graph"]["edge_count"] == 1
     assert "workflow:" in yaml_output
+
+
+def test_get_conversion_includes_nested_source_graph_summary(tmp_path, monkeypatch) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-nested-source-graph.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    service = ConversionService()
+
+    workflow = IRWorkflow(
+        id="nested-source",
+        name="Nested source",
+        nodes=[
+            IRNode(
+                id="start",
+                node_type=IRNodeType.START,
+                title="Start",
+                position=IRPosition(),
+            ),
+            IRNode(
+                id="loop",
+                node_type=IRNodeType.LOOP_ARRAY,
+                title="Loop",
+                position=IRPosition(x=280, y=0),
+                children=[
+                    IRNode(
+                        id="child-code",
+                        node_type=IRNodeType.CODE,
+                        title="Child Code",
+                        position=IRPosition(x=560, y=0),
+                        outputs=[IRVariable(name="result", var_type=IRVariableType.STRING)],
+                    )
+                ],
+                child_edges=[
+                    IREdge(source_node_id="loop", target_node_id="child-code"),
+                ],
+            ),
+            IRNode(
+                id="end",
+                node_type=IRNodeType.END,
+                title="End",
+                position=IRPosition(x=840, y=0),
+            ),
+        ],
+        edges=[
+            IREdge(source_node_id="start", target_node_id="loop"),
+            IREdge(source_node_id="loop", target_node_id="end"),
+        ],
+    )
+
+    monkeypatch.setattr(service.engine.coze_parser, "parse_file", lambda content, fmt: workflow)
+
+    with session_factory() as db:
+        result = service.convert_uploaded_file(db, b"{}", "nested.json")
+        persisted = service.get_conversion(db, result["conversion_id"])
+
+    source_nodes = {node["id"]: node for node in persisted["source_graph"]["nodes"]}
+
+    assert persisted["source_graph"]["node_count"] == 4
+    assert persisted["source_graph"]["edge_count"] == 3
+    assert source_nodes["loop"]["parent_id"] is None
+    assert source_nodes["child-code"]["parent_id"] == "loop"
+    assert persisted["target_graph"]["node_count"] >= 3
 
 
 def test_list_conversions_returns_paginated_history_without_sync_tasks(tmp_path) -> None:

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,7 +129,8 @@ Execute conversion pipeline.
 
 ### `GET /convert/{id}`
 
-Get conversion result.
+Get conversion result, including the persisted report plus `source_graph` / `target_graph` summaries
+for visual diff views.
 
 ### `GET /convert/{id}/dsl`
 

--- a/frontend/src/components/diff/ConversionVisualBoard.tsx
+++ b/frontend/src/components/diff/ConversionVisualBoard.tsx
@@ -1,0 +1,246 @@
+import type {
+  ConversionReport,
+  MappingStatus,
+  NodeConversionResult,
+  WorkflowGraphNodeSummary,
+  WorkflowGraphSummary,
+} from "../../types/ir";
+
+const LANE_CONFIG: Array<{
+  status: MappingStatus;
+  label: string;
+  tone: "green" | "amber" | "red" | "slate";
+  description: string;
+}> = [
+  {
+    status: "mapped",
+    label: "Mapped",
+    tone: "green",
+    description: "Cleanly translated to Dify nodes with matching structure.",
+  },
+  {
+    status: "partial",
+    label: "Partial",
+    tone: "amber",
+    description: "Converted, but with warnings, gaps, or downgraded behavior.",
+  },
+  {
+    status: "unmappable",
+    label: "Unmappable",
+    tone: "red",
+    description: "No safe Dify equivalent was generated for this Coze node.",
+  },
+  {
+    status: "skipped",
+    label: "Skipped",
+    tone: "slate",
+    description: "Intentionally omitted from the output graph or inlined elsewhere.",
+  },
+];
+
+export default function ConversionVisualBoard({
+  report,
+  sourceGraph,
+  targetGraph,
+}: {
+  report: ConversionReport;
+  sourceGraph: WorkflowGraphSummary | null;
+  targetGraph: WorkflowGraphSummary | null;
+}) {
+  const sourceIndex = toNodeIndex(sourceGraph);
+  const targetIndex = toNodeIndex(targetGraph);
+
+  return (
+    <div className="change-board">
+      <div className="change-overview-grid">
+        <GraphSummaryCard
+          label="Coze Source"
+          tone="accent"
+          graph={sourceGraph}
+          fallback="Source graph summary is not available for this conversion snapshot."
+        />
+        <GraphSummaryCard
+          label="Dify Target"
+          tone="blue"
+          graph={targetGraph}
+          fallback="Target graph summary is not available for this conversion snapshot."
+        />
+      </div>
+
+      <div className="change-lane-grid" style={{ marginTop: 20 }}>
+        {LANE_CONFIG.map((lane, index) => {
+          const items = report.node_results.filter((result) => result.status === lane.status);
+          return (
+            <section key={lane.status} className={`card change-lane change-lane--${lane.tone} fade-in fade-in-${index + 1}`}>
+              <div className="change-lane__header">
+                <div>
+                  <div className="change-lane__title">{lane.label}</div>
+                  <p className="change-lane__description">{lane.description}</p>
+                </div>
+                <div className="change-lane__count">{items.length}</div>
+              </div>
+
+              <div className="change-lane__body">
+                {items.length > 0 ? (
+                  items.map((result) => (
+                    <ConversionNodeCard
+                      key={result.source_node_id}
+                      result={result}
+                      sourceNode={sourceIndex[result.source_node_id] || null}
+                      targetNode={result.target_node_id ? targetIndex[result.target_node_id] || null : null}
+                    />
+                  ))
+                ) : (
+                  <div className="change-lane__empty">No {lane.label.toLowerCase()} nodes in this conversion.</div>
+                )}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function GraphSummaryCard({
+  label,
+  tone,
+  graph,
+  fallback,
+}: {
+  label: string;
+  tone: "accent" | "blue";
+  graph: WorkflowGraphSummary | null;
+  fallback: string;
+}) {
+  if (!graph) {
+    return (
+      <div className={`card change-panel change-panel--${tone}`}>
+        <div className="change-panel__label">{label}</div>
+        <div className="change-panel__empty">{fallback}</div>
+      </div>
+    );
+  }
+
+  const nestedCount = graph.nodes.filter((node) => node.parent_id).length;
+  const previewNodes = graph.nodes.slice(0, 6);
+
+  return (
+    <div className={`card change-panel change-panel--${tone}`}>
+      <div className="change-panel__label">{label}</div>
+
+      <div className="change-panel__metrics">
+        <MetricPill label="Nodes" value={graph.node_count} />
+        <MetricPill label="Edges" value={graph.edge_count} />
+        <MetricPill label="Nested" value={nestedCount} />
+      </div>
+
+      <div className="change-panel__chips">
+        {previewNodes.map((node) => (
+          <div key={node.id} className="change-chip">
+            <div className="change-chip__title">{node.title || node.id}</div>
+            <div className="change-chip__meta">
+              {node.type || "unknown"} • {node.id}
+            </div>
+          </div>
+        ))}
+        {graph.nodes.length > previewNodes.length ? (
+          <div className="change-chip change-chip--more">+{graph.nodes.length - previewNodes.length} more</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ConversionNodeCard({
+  result,
+  sourceNode,
+  targetNode,
+}: {
+  result: NodeConversionResult;
+  sourceNode: WorkflowGraphNodeSummary | null;
+  targetNode: WorkflowGraphNodeSummary | null;
+}) {
+  const parentLabel = sourceNode?.parent_id ? `Nested in ${sourceNode.parent_id}` : null;
+
+  return (
+    <article className={`change-item change-item--${toneForMappingStatus(result.status)}`}>
+      <div className="change-item__header">
+        <div>
+          <div className="change-item__title">{sourceNode?.title || result.source_node_id}</div>
+          <div className="change-item__meta">
+            {sourceNode?.type || result.source_node_type} • {result.source_node_id}
+          </div>
+        </div>
+        <span className={`badge ${badgeClassForMappingStatus(result.status)}`}>{result.status}</span>
+      </div>
+
+      {parentLabel ? <div className="change-item__hint">{parentLabel}</div> : null}
+
+      <div className="change-route">
+        <div className="change-route__node">
+          <div className="change-route__label">Coze</div>
+          <div className="change-route__title">{sourceNode?.title || result.source_node_id}</div>
+        </div>
+        <div className="change-route__arrow">→</div>
+        <div className="change-route__node">
+          <div className="change-route__label">Dify</div>
+          <div className="change-route__title">
+            {targetNode?.title || result.target_node_id || "No target node emitted"}
+          </div>
+          <div className="change-route__meta">
+            {targetNode?.type || result.target_node_type || "unmapped"}
+          </div>
+        </div>
+      </div>
+
+      {result.warnings.length > 0 ? (
+        <div className="change-item__note change-item__note--warning">{result.warnings.join(" ")}</div>
+      ) : null}
+      {result.errors.length > 0 ? (
+        <div className="change-item__note change-item__note--error">{result.errors.join(" ")}</div>
+      ) : null}
+    </article>
+  );
+}
+
+function MetricPill({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="change-metric">
+      <div className="change-metric__value">{value}</div>
+      <div className="change-metric__label">{label}</div>
+    </div>
+  );
+}
+
+function toNodeIndex(graph: WorkflowGraphSummary | null) {
+  return Object.fromEntries((graph?.nodes || []).map((node) => [node.id, node]));
+}
+
+function toneForMappingStatus(status: MappingStatus) {
+  switch (status) {
+    case "mapped":
+      return "green";
+    case "partial":
+      return "amber";
+    case "unmappable":
+      return "red";
+    case "skipped":
+    default:
+      return "slate";
+  }
+}
+
+function badgeClassForMappingStatus(status: MappingStatus) {
+  switch (status) {
+    case "mapped":
+      return "badge--mapped";
+    case "partial":
+      return "badge--partial";
+    case "unmappable":
+      return "badge--unmappable";
+    case "skipped":
+    default:
+      return "badge--skipped";
+  }
+}

--- a/frontend/src/components/diff/SyncVisualBoard.tsx
+++ b/frontend/src/components/diff/SyncVisualBoard.tsx
@@ -1,0 +1,216 @@
+import type {
+  SyncConflictStrategy,
+  SyncRunItem,
+} from "../../types/sync";
+
+const STATUS_CONFIG: Array<{
+  status: SyncRunItem["status"];
+  label: string;
+  tone: "green" | "blue" | "amber" | "red" | "slate";
+  description: string;
+}> = [
+  {
+    status: "created",
+    label: "Created",
+    tone: "green",
+    description: "New Dify apps that will be created or were created from Coze source workflows.",
+  },
+  {
+    status: "updated",
+    label: "Updated",
+    tone: "blue",
+    description: "Existing Dify apps that will be refreshed with newer converted DSL.",
+  },
+  {
+    status: "conflict",
+    label: "Conflicts",
+    tone: "amber",
+    description: "Source and target both changed and now require an explicit resolution strategy.",
+  },
+  {
+    status: "unsupported",
+    label: "Unsupported",
+    tone: "amber",
+    description: "Changes that were detected but intentionally blocked until policy or feature support exists.",
+  },
+  {
+    status: "failed",
+    label: "Failed",
+    tone: "red",
+    description: "Operations that hit conversion, validation, or target write failures.",
+  },
+  {
+    status: "skipped",
+    label: "Skipped",
+    tone: "slate",
+    description: "Workflows intentionally left unchanged because no target action was needed.",
+  },
+];
+
+export default function SyncVisualBoard({
+  items,
+  emptyMessage,
+  emptyIcon,
+  onResolveConflict,
+  resolvingConflictId,
+}: {
+  items: SyncRunItem[];
+  emptyMessage: string;
+  emptyIcon: string;
+  onResolveConflict?: (conflictId: string, strategy: SyncConflictStrategy) => Promise<void> | void;
+  resolvingConflictId?: string | null;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="empty-state card" style={{ borderStyle: "dashed" }}>
+        <div className="empty-state__icon">{emptyIcon}</div>
+        <p className="empty-state__text">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="change-lane-grid">
+      {STATUS_CONFIG.map((lane, index) => {
+        const laneItems = items.filter((item) => item.status === lane.status);
+        return (
+          <section key={lane.status} className={`card change-lane change-lane--${lane.tone} fade-in fade-in-${(index % 4) + 1}`}>
+            <div className="change-lane__header">
+              <div>
+                <div className="change-lane__title">{lane.label}</div>
+                <p className="change-lane__description">{lane.description}</p>
+              </div>
+              <div className="change-lane__count">{laneItems.length}</div>
+            </div>
+
+            <div className="change-lane__body">
+              {laneItems.length > 0 ? (
+                laneItems.map((item, itemIndex) => (
+                  <SyncRunCard
+                    key={`${item.source_workflow_id || "unknown"}-${item.target_app_id || "target"}-${itemIndex}`}
+                    item={item}
+                    onResolveConflict={onResolveConflict}
+                    resolvingConflictId={resolvingConflictId}
+                  />
+                ))
+              ) : (
+                <div className="change-lane__empty">No {lane.label.toLowerCase()} workflows in this set.</div>
+              )}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function SyncRunCard({
+  item,
+  onResolveConflict,
+  resolvingConflictId,
+}: {
+  item: SyncRunItem;
+  onResolveConflict?: (conflictId: string, strategy: SyncConflictStrategy) => Promise<void> | void;
+  resolvingConflictId?: string | null;
+}) {
+  const canResolve = Boolean(onResolveConflict && item.status === "conflict" && item.source_workflow_id);
+  const resolving = resolvingConflictId === item.source_workflow_id;
+
+  return (
+    <article className={`change-item change-item--${toneForRunStatus(item.status)}`}>
+      <div className="change-item__header">
+        <div>
+          <div className="change-item__title">{item.source_workflow_name || item.source_workflow_id || "Unknown workflow"}</div>
+          <div className="change-item__meta">
+            {item.source_workflow_id || "missing-id"} • {item.action.toUpperCase()}
+          </div>
+        </div>
+        <span className={`badge ${badgeClassForRunStatus(item.status)}`}>{item.status}</span>
+      </div>
+
+      <div className="change-item__hint">
+        Target {item.target_app_id ? item.target_app_id : "will be determined during write"}
+      </div>
+
+      <div className="change-item__note">{item.message}</div>
+
+      {item.resolution ? (
+        <div className="change-item__note change-item__note--info">
+          {item.resolution.status} • {item.resolution.strategy}
+          {item.resolution.resolved_at ? ` • ${formatTimestamp(item.resolution.resolved_at)}` : ""}
+        </div>
+      ) : item.status === "conflict" ? (
+        <div className="change-item__note change-item__note--warning">Pending resolution</div>
+      ) : null}
+
+      {canResolve ? (
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
+          <button
+            className="btn btn-secondary"
+            style={{ padding: "6px 10px", fontSize: "0.72rem" }}
+            disabled={resolving}
+            onClick={() => void onResolveConflict?.(item.source_workflow_id, "source_wins")}
+          >
+            {resolving ? "Resolving..." : "Source Wins"}
+          </button>
+          <button
+            className="btn btn-ghost"
+            style={{ padding: "6px 10px", fontSize: "0.72rem" }}
+            disabled={resolving}
+            onClick={() => void onResolveConflict?.(item.source_workflow_id, "target_wins")}
+          >
+            Keep Target
+          </button>
+          <button
+            className="btn btn-ghost"
+            style={{ padding: "6px 10px", fontSize: "0.72rem" }}
+            disabled={resolving}
+            onClick={() => void onResolveConflict?.(item.source_workflow_id, "manual")}
+          >
+            Mark Manual
+          </button>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function badgeClassForRunStatus(status: SyncRunItem["status"]) {
+  switch (status) {
+    case "created":
+    case "updated":
+      return "badge--mapped";
+    case "skipped":
+      return "badge--skipped";
+    case "unsupported":
+    case "conflict":
+      return "badge--partial";
+    case "failed":
+    default:
+      return "badge--unmappable";
+  }
+}
+
+function toneForRunStatus(status: SyncRunItem["status"]) {
+  switch (status) {
+    case "created":
+      return "green";
+    case "updated":
+      return "blue";
+    case "skipped":
+      return "slate";
+    case "unsupported":
+    case "conflict":
+      return "amber";
+    case "failed":
+    default:
+      return "red";
+  }
+}
+
+function formatTimestamp(value: string | undefined) {
+  if (!value) {
+    return "Pending";
+  }
+  return new Date(value).toLocaleString();
+}

--- a/frontend/src/pages/DiffPage.tsx
+++ b/frontend/src/pages/DiffPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import ConversionVisualBoard from "../components/diff/ConversionVisualBoard";
 import StepNavigation from "../components/layout/StepNavigation";
 import MappingTable from "../components/mapping/MappingTable";
 import ConversionReportView from "../components/result/ConversionReport";
@@ -9,12 +10,21 @@ import { getConversion } from "../api/conversion";
 export default function DiffPage() {
   const { conversionId } = useParams();
   const navigate = useNavigate();
-  const { conversionId: storedConversionId, conversionReport, setConversion } = useWorkflowStore();
+  const {
+    conversionId: storedConversionId,
+    conversionDetail,
+    conversionReport,
+    setConversion,
+  } = useWorkflowStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const activeDetail =
+    conversionDetail && storedConversionId === conversionId ? conversionDetail : null;
+  const activeReport =
+    activeDetail?.report || (storedConversionId === conversionId ? conversionReport : null);
 
   useEffect(() => {
-    if (!conversionId || (conversionReport && storedConversionId === conversionId)) {
+    if (!conversionId || activeDetail) {
       return;
     }
 
@@ -24,7 +34,7 @@ export default function DiffPage() {
     getConversion(conversionId)
       .then((result) => {
         if (!cancelled) {
-          setConversion(result.conversion_id, result.report);
+          setConversion(result.conversion_id, result.report, result);
         }
       })
       .catch((e: any) => {
@@ -41,9 +51,9 @@ export default function DiffPage() {
     return () => {
       cancelled = true;
     };
-  }, [conversionId, conversionReport, setConversion, storedConversionId]);
+  }, [activeDetail, conversionId, setConversion]);
 
-  if (loading && !conversionReport) {
+  if (loading && !activeReport) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={2} />
@@ -55,7 +65,7 @@ export default function DiffPage() {
     );
   }
 
-  if (error && !conversionReport) {
+  if (error && !activeReport) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={2} />
@@ -67,7 +77,7 @@ export default function DiffPage() {
     );
   }
 
-  if (!conversionReport) {
+  if (!activeReport) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={2} />
@@ -90,11 +100,25 @@ export default function DiffPage() {
         </p>
       </div>
 
-      <ConversionReportView report={conversionReport} />
+      <ConversionReportView report={activeReport} />
+
+      <div style={{ marginTop: 24 }}>
+        <div className="section-title" style={{ marginBottom: 12 }}>Visual Diff</div>
+        <p className="section-subtitle">
+          Grouped by mapping outcome, with persisted source and target graph summaries.
+        </p>
+        <div style={{ marginTop: 16 }}>
+          <ConversionVisualBoard
+            report={activeReport}
+            sourceGraph={activeDetail?.source_graph || null}
+            targetGraph={activeDetail?.target_graph || null}
+          />
+        </div>
+      </div>
 
       <div style={{ marginTop: 24 }}>
         <div className="section-title" style={{ marginBottom: 16 }}>Node Details</div>
-        <MappingTable results={conversionReport.node_results} />
+        <MappingTable results={activeReport.node_results} />
       </div>
 
       {error && (

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -10,12 +10,21 @@ import { getConversion } from "../api/conversion";
 
 export default function ResultPage() {
   const { conversionId } = useParams();
-  const { conversionId: storedConversionId, conversionReport, setConversion } = useWorkflowStore();
+  const {
+    conversionId: storedConversionId,
+    conversionDetail,
+    conversionReport,
+    setConversion,
+  } = useWorkflowStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const activeDetail =
+    conversionDetail && storedConversionId === conversionId ? conversionDetail : null;
+  const activeReport =
+    activeDetail?.report || (storedConversionId === conversionId ? conversionReport : null);
 
   useEffect(() => {
-    if (!conversionId || (conversionReport && storedConversionId === conversionId)) {
+    if (!conversionId || activeDetail) {
       return;
     }
 
@@ -25,7 +34,7 @@ export default function ResultPage() {
     getConversion(conversionId)
       .then((result) => {
         if (!cancelled) {
-          setConversion(result.conversion_id, result.report);
+          setConversion(result.conversion_id, result.report, result);
         }
       })
       .catch((e: any) => {
@@ -42,9 +51,9 @@ export default function ResultPage() {
     return () => {
       cancelled = true;
     };
-  }, [conversionId, conversionReport, setConversion, storedConversionId]);
+  }, [activeDetail, conversionId, setConversion]);
 
-  if (loading && !conversionReport) {
+  if (loading && !activeReport) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={3} />
@@ -56,7 +65,7 @@ export default function ResultPage() {
     );
   }
 
-  if ((!conversionReport || !conversionId) && error) {
+  if ((!activeReport || !conversionId) && error) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={3} />
@@ -68,7 +77,7 @@ export default function ResultPage() {
     );
   }
 
-  if (!conversionReport || !conversionId) {
+  if (!activeReport || !conversionId) {
     return (
       <div className="fade-in">
         <StepNavigation currentStep={3} />
@@ -87,11 +96,11 @@ export default function ResultPage() {
       <div className="page-header">
         <h1 className="page-title">Export Result</h1>
         <p className="page-description">
-          Workflow "{conversionReport.workflow_name}" — conversion complete
+          Workflow "{activeReport.workflow_name}" — conversion complete
         </p>
       </div>
 
-      <ConversionReportView report={conversionReport} />
+      <ConversionReportView report={activeReport} />
 
       {error && (
         <div className="alert alert--error" style={{ marginTop: 20 }}>
@@ -122,7 +131,7 @@ export default function ResultPage() {
         </div>
       </div>
 
-      <WarningList results={conversionReport.node_results} />
+      <WarningList results={activeReport.node_results} />
     </div>
   );
 }

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import SyncVisualBoard from "../components/diff/SyncVisualBoard";
 import SyncHistoryTable from "../components/sync/SyncHistoryTable";
 import { getSyncHistoryDetail, listSyncHistory } from "../api/sync";
 import type { SyncHistoryEntry, SyncRunDetail } from "../types/sync";
@@ -147,6 +148,17 @@ export default function SyncHistoryPage() {
                   ) : null}
                 </div>
               ) : null}
+
+              <div style={{ marginTop: 20 }}>
+                <div className="section-title" style={{ fontSize: "0.95rem", marginBottom: 12 }}>
+                  Workflow Changes
+                </div>
+                <SyncVisualBoard
+                  items={selectedRun.items}
+                  emptyMessage="No workflow changes were persisted for this run"
+                  emptyIcon="📭"
+                />
+              </div>
             </div>
           ) : null}
         </>

--- a/frontend/src/pages/SyncPage.tsx
+++ b/frontend/src/pages/SyncPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import SyncVisualBoard from "../components/diff/SyncVisualBoard";
 import SyncHistoryTable from "../components/sync/SyncHistoryTable";
 import {
   cancelSyncSchedule,
@@ -21,7 +22,6 @@ import type {
   SyncDiffPreview,
   SyncHistoryEntry,
   SyncRunDetail,
-  SyncRunItem,
   SyncStatus,
   SyncSummary,
 } from "../types/sync";
@@ -536,7 +536,7 @@ export default function SyncPage() {
             </div>
 
             <div style={{ marginTop: 18 }}>
-              <RunItemsTable
+              <SyncVisualBoard
                 items={diffPreview.items}
                 emptyMessage="No diff preview available yet"
                 emptyIcon="👁"
@@ -553,7 +553,7 @@ export default function SyncPage() {
 
       <div style={{ marginTop: 28 }}>
         <div className="section-title" style={{ marginBottom: 12 }}>Run Details</div>
-        <RunItemsTable
+        <SyncVisualBoard
           items={selectedRun?.items || []}
           emptyMessage="No persisted sync run selected yet"
           emptyIcon="🧭"
@@ -676,141 +676,4 @@ function RunAuditPanel({ audit }: { audit: NonNullable<SyncRunDetail["audit"]> }
       ) : null}
     </div>
   );
-}
-
-function RunItemsTable({
-  items,
-  emptyMessage,
-  emptyIcon,
-  onResolveConflict,
-  resolvingConflictId,
-}: {
-  items: SyncRunItem[];
-  emptyMessage: string;
-  emptyIcon: string;
-  onResolveConflict?: (conflictId: string, strategy: SyncConflictStrategy) => Promise<void> | void;
-  resolvingConflictId?: string | null;
-}) {
-  if (items.length === 0) {
-    return (
-      <div className="empty-state card" style={{ borderStyle: "dashed" }}>
-        <div className="empty-state__icon">{emptyIcon}</div>
-        <p className="empty-state__text">{emptyMessage}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="table-wrap">
-      <table className="c2d-table">
-        <thead>
-          <tr>
-            <th>Workflow</th>
-            <th>Action</th>
-            <th>Status</th>
-            <th>Target</th>
-            <th>Message</th>
-            <th>Resolution</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item, index) => {
-            const canResolve = Boolean(onResolveConflict && item.status === "conflict" && item.source_workflow_id);
-            const resolving = resolvingConflictId === item.source_workflow_id;
-
-            return (
-              <tr key={`${item.source_workflow_id || "unknown"}-${index}`}>
-                <td>
-                  <div style={{ fontWeight: 600, color: "var(--c-text-primary)" }}>
-                    {item.source_workflow_name || "Unknown workflow"}
-                  </div>
-                  <div style={{ fontSize: "0.72rem", color: "var(--c-text-tertiary)", fontFamily: "var(--font-mono)" }}>
-                    {item.source_workflow_id || "missing-id"}
-                  </div>
-                </td>
-                <td style={{ textTransform: "uppercase", fontSize: "0.72rem", letterSpacing: "0.06em" }}>
-                  {item.action}
-                </td>
-                <td>
-                  <span className={`badge ${runItemBadgeClass(item.status)}`}>{item.status}</span>
-                </td>
-                <td style={{ fontFamily: "var(--font-mono)", fontSize: "0.78rem" }}>
-                  {item.target_app_id || "—"}
-                </td>
-                <td>{item.message}</td>
-                <td style={{ minWidth: 180 }}>
-                  {item.resolution ? (
-                    <>
-                      <div style={{ fontSize: "0.76rem", fontWeight: 600 }}>
-                        {item.resolution.status}
-                      </div>
-                      <div style={{ fontSize: "0.72rem", color: "var(--c-text-tertiary)" }}>
-                        {item.resolution.strategy}
-                        {item.resolution.resolved_at ? ` • ${formatTimestamp(item.resolution.resolved_at)}` : ""}
-                      </div>
-                    </>
-                  ) : item.status === "conflict" ? (
-                    <span style={{ fontSize: "0.76rem", color: "var(--c-amber)" }}>Pending resolution</span>
-                  ) : (
-                    <span style={{ fontSize: "0.76rem", color: "var(--c-text-tertiary)" }}>—</span>
-                  )}
-                </td>
-                <td style={{ minWidth: 260 }}>
-                  {canResolve ? (
-                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                      <button
-                        className="btn btn-secondary"
-                        style={{ padding: "6px 10px", fontSize: "0.72rem" }}
-                        disabled={resolving}
-                        onClick={() => void onResolveConflict?.(item.source_workflow_id, "source_wins")}
-                      >
-                        {resolving ? "Resolving..." : "Source Wins"}
-                      </button>
-                      <button
-                        className="btn btn-ghost"
-                        style={{ padding: "6px 10px", fontSize: "0.72rem" }}
-                        disabled={resolving}
-                        onClick={() => void onResolveConflict?.(item.source_workflow_id, "target_wins")}
-                      >
-                        Keep Target
-                      </button>
-                      <button
-                        className="btn btn-ghost"
-                        style={{ padding: "6px 10px", fontSize: "0.72rem" }}
-                        disabled={resolving}
-                        onClick={() => void onResolveConflict?.(item.source_workflow_id, "manual")}
-                      >
-                        Mark Manual
-                      </button>
-                    </div>
-                  ) : (
-                    <span style={{ fontSize: "0.76rem", color: "var(--c-text-tertiary)" }}>
-                      {item.status === "conflict" ? "Select a persisted run to resolve this conflict." : "—"}
-                    </span>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function runItemBadgeClass(status: SyncRunItem["status"]) {
-  switch (status) {
-    case "created":
-    case "updated":
-      return "badge--mapped";
-    case "skipped":
-      return "badge--skipped";
-    case "unsupported":
-    case "conflict":
-      return "badge--partial";
-    case "failed":
-    default:
-      return "badge--unmappable";
-  }
 }

--- a/frontend/src/store/workflowStore.ts
+++ b/frontend/src/store/workflowStore.ts
@@ -1,15 +1,16 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import type { ConversionReport, WorkflowNode } from "../types/ir";
+import type { ConversionDetail, ConversionReport, WorkflowNode } from "../types/ir";
 
 interface WorkflowState {
   sourceMethod: "upload" | "api" | "database" | null;
   sourceNodes: WorkflowNode[];
   conversionId: string | null;
   conversionReport: ConversionReport | null;
+  conversionDetail: ConversionDetail | null;
   setSourceMethod: (method: "upload" | "api" | "database") => void;
   setSourceNodes: (nodes: WorkflowNode[]) => void;
-  setConversion: (id: string, report: ConversionReport) => void;
+  setConversion: (id: string, report: ConversionReport, detail?: ConversionDetail | null) => void;
   reset: () => void;
 }
 
@@ -23,17 +24,29 @@ const initialState: WorkflowStoreData = {
   sourceNodes: [],
   conversionId: null,
   conversionReport: null,
+  conversionDetail: null,
 };
 
 export const useWorkflowStore = create<WorkflowState>()(
   persist((set) => ({
     ...initialState,
-  setSourceMethod: (method) => set({ sourceMethod: method }),
-  setSourceNodes: (nodes) => set({ sourceNodes: nodes }),
-  setConversion: (id, report) => set({ conversionId: id, conversionReport: report }),
-  reset: () => set(initialState),
+    setSourceMethod: (method) => set({ sourceMethod: method }),
+    setSourceNodes: (nodes) => set({ sourceNodes: nodes }),
+    setConversion: (id, report, detail = null) =>
+      set({
+        conversionId: id,
+        conversionReport: report,
+        conversionDetail: detail,
+      }),
+    reset: () => set(initialState),
   }), {
     name: "coze2dify-workflow",
     storage: createJSONStorage(() => sessionStorage),
+    partialize: (state) => ({
+      sourceMethod: state.sourceMethod,
+      sourceNodes: state.sourceNodes,
+      conversionId: state.conversionId,
+      conversionReport: state.conversionReport,
+    }),
   }),
 );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -363,6 +363,216 @@ table.c2d-table {
   letter-spacing: 0.06em;
 }
 
+/* ── Change Boards ── */
+.change-board {
+  display: grid;
+  gap: 16px;
+}
+
+.change-overview-grid,
+.change-lane-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.change-panel,
+.change-lane {
+  padding: 20px;
+  background:
+    radial-gradient(circle at top right, rgba(255,255,255,0.03), transparent 42%),
+    linear-gradient(180deg, rgba(255,255,255,0.015), transparent 55%),
+    var(--c-surface-1);
+}
+
+.change-panel--accent,
+.change-lane--green {
+  border-color: #10b98133;
+}
+
+.change-panel--blue,
+.change-lane--blue {
+  border-color: #3b82f633;
+}
+
+.change-lane--amber {
+  border-color: #f59e0b33;
+}
+
+.change-lane--red {
+  border-color: #ef444433;
+}
+
+.change-lane--slate {
+  border-color: rgba(100,116,139,0.3);
+}
+
+.change-panel__label,
+.change-lane__title {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  color: var(--c-text-primary);
+}
+
+.change-panel__empty,
+.change-lane__description,
+.change-lane__empty {
+  margin-top: 8px;
+  font-size: 0.8rem;
+  color: var(--c-text-tertiary);
+}
+
+.change-panel__metrics {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.change-panel__chips {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.change-chip,
+.change-metric {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--c-border-subtle);
+  background: rgba(10,14,23,0.55);
+}
+
+.change-chip {
+  min-width: 140px;
+}
+
+.change-chip--more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c-text-secondary);
+  font-family: var(--font-display);
+}
+
+.change-chip__title,
+.change-item__title,
+.change-route__title {
+  font-weight: 700;
+  color: var(--c-text-primary);
+}
+
+.change-chip__meta,
+.change-metric__label,
+.change-item__meta,
+.change-route__label,
+.change-route__meta,
+.change-item__hint {
+  margin-top: 4px;
+  font-size: 0.74rem;
+  color: var(--c-text-tertiary);
+}
+
+.change-metric__value,
+.change-lane__count {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--c-text-primary);
+}
+
+.change-lane__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.change-lane__body {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.change-item {
+  padding: 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--c-border-subtle);
+  background: rgba(10,14,23,0.62);
+}
+
+.change-item--green {
+  border-color: #10b98130;
+}
+
+.change-item--blue {
+  border-color: #3b82f630;
+}
+
+.change-item--amber {
+  border-color: #f59e0b30;
+}
+
+.change-item--red {
+  border-color: #ef444430;
+}
+
+.change-item--slate {
+  border-color: rgba(100,116,139,0.24);
+}
+
+.change-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.change-route {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.change-route__node {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--c-border-subtle);
+  background: rgba(21,27,43,0.72);
+}
+
+.change-route__arrow {
+  font-family: var(--font-display);
+  color: var(--c-text-secondary);
+}
+
+.change-item__note {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  background: rgba(21,27,43,0.72);
+  color: var(--c-text-secondary);
+}
+
+.change-item__note--warning {
+  background: var(--c-amber-dim);
+  color: var(--c-amber);
+}
+
+.change-item__note--error {
+  background: var(--c-red-dim);
+  color: var(--c-red);
+}
+
+.change-item__note--info {
+  background: var(--c-blue-dim);
+  color: var(--c-blue);
+}
+
 /* ── Section Headers ── */
 .section-title {
   font-family: var(--font-display);

--- a/frontend/src/types/ir.ts
+++ b/frontend/src/types/ir.ts
@@ -30,6 +30,19 @@ export interface WorkflowNode {
   title: string;
 }
 
+export interface WorkflowGraphNodeSummary {
+  id: string;
+  type: string;
+  title: string;
+  parent_id: string | null;
+}
+
+export interface WorkflowGraphSummary {
+  node_count: number;
+  edge_count: number;
+  nodes: WorkflowGraphNodeSummary[];
+}
+
 export interface UploadResult {
   workflow_id: string;
   node_count: number;
@@ -102,6 +115,8 @@ export interface ConversionDetail {
   source_workflow_id: string;
   source_workflow_name: string;
   dsl: Record<string, unknown>;
+  source_graph: WorkflowGraphSummary | null;
+  target_graph: WorkflowGraphSummary | null;
   report: ConversionReport;
   write_result: WriteResult | null;
   audit: ConversionAudit | null;


### PR DESCRIPTION
## Summary
- add persisted source/target graph summaries to conversion detail for visual diff views
- add grouped visual diff boards for conversion preview, sync preview, sync runs, and sync history
- keep conversion detail out of persisted session storage while still hydrating it in memory

## Testing
- ./scripts/ci-local.sh
- cd frontend && npx tsc --noEmit
- cd frontend && npm run build

Closes #26