### PR TITLE
Define delete sync policy and surface it in sync UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Some endpoints below exist in the API surface but are not all fully wired in the
 ### Sync
 
 The sync API covers persisted config, manual execution, diff preview, conflict resolution, and cron scheduling.
+Delete gaps are governed by an explicit policy layer; see [`docs/delete-sync-policy.md`](docs/delete-sync-policy.md).
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -160,7 +161,7 @@ The sync API covers persisted config, manual execution, diff preview, conflict r
 ### Safety Notes
 
 - Sync config and direct-write responses no longer echo raw database URLs; API payloads return redacted `display_url` references instead.
-- Persisted sync runs and conversion tasks now carry operator audit metadata, including redacted source/target DB references and the latest write attempt details.
+- Persisted sync runs and conversion tasks now carry operator audit metadata, including redacted source/target DB references, delete-policy metadata, and the latest write attempt details.
 - Reusing a saved sync config from the UI does not require re-entering the stored DB URL; leaving the redacted field blank keeps the persisted value unchanged.
 - Direct DB writes and sync remain operator-driven workflows. Treat them as privileged actions, and keep them behind trusted environments and credentials management.
 
@@ -199,7 +200,7 @@ The mapping table is the target design. Actual support quality varies by node ty
 | Continue | — | 🔴 Unmappable |
 | Comment | — | ⚪ Skipped |
 
-> See the full 42-type mapping in [`docs/node-mapping.md`](docs/node-mapping.md). Architecture details in [`docs/architecture.md`](docs/architecture.md). API reference in [`docs/api.md`](docs/api.md). Dev Mode guide in [`docs/dev-mode.md`](docs/dev-mode.md).
+> See the full 42-type mapping in [`docs/node-mapping.md`](docs/node-mapping.md). Architecture details in [`docs/architecture.md`](docs/architecture.md). API reference in [`docs/api.md`](docs/api.md). Delete policy guide in [`docs/delete-sync-policy.md`](docs/delete-sync-policy.md). Dev Mode guide in [`docs/dev-mode.md`](docs/dev-mode.md).
 
 ## 📁 Project Structure
 

--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -11,6 +11,7 @@ from core.coze.db_reader import CozeDbReader
 from core.dify.db_reader import DifyDbReader
 from core.security.redaction import build_database_ref, sanitize_exception
 from core.sync.conflict_resolver import ConflictStrategy
+from core.sync.delete_policy import DeleteMode, build_delete_policy, ensure_delete_mode_supported
 from core.sync.scheduler import SyncScheduler
 from core.sync.sync_engine import SyncEngine
 from db.database import SessionLocal, get_db
@@ -29,6 +30,7 @@ class SyncConfigRequest(BaseModel):
     coze_db_url: str
     dify_db_url: str
     sync_mode: str = "manual"
+    delete_mode: DeleteMode = DeleteMode.OBSERVE_ONLY
     cron_expression: str | None = None
 
 
@@ -161,6 +163,10 @@ async def resolve_conflict(
 
 def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
     config: SyncConfig | None = None
+    try:
+        delete_mode = ensure_delete_mode_supported(req.delete_mode)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if req.config_id is not None:
         config = db.get(SyncConfig, req.config_id)
@@ -173,6 +179,7 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
                 SyncConfig.coze_db_url == req.coze_db_url,
                 SyncConfig.dify_db_url == req.dify_db_url,
                 SyncConfig.sync_mode == req.sync_mode,
+                SyncConfig.delete_mode == delete_mode.value,
             )
             .order_by(SyncConfig.updated_at.desc(), SyncConfig.id.desc())
         )
@@ -187,6 +194,7 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
             coze_db_url=coze_db_url,
             dify_db_url=dify_db_url,
             sync_mode=req.sync_mode,
+            delete_mode=delete_mode.value,
             cron_expression=req.cron_expression,
             enabled=True,
         )
@@ -196,6 +204,7 @@ def _upsert_sync_config(db: Session, req: SyncConfigRequest) -> SyncConfig:
         config.coze_db_url = coze_db_url
         config.dify_db_url = dify_db_url
         config.sync_mode = req.sync_mode
+        config.delete_mode = delete_mode.value
         config.cron_expression = req.cron_expression
         config.enabled = True
 
@@ -217,6 +226,8 @@ def _serialize_config(config: SyncConfig | None) -> dict[str, object] | None:
         "has_stored_coze_db_url": bool(config.coze_db_url),
         "has_stored_dify_db_url": bool(config.dify_db_url),
         "sync_mode": config.sync_mode,
+        "delete_mode": config.delete_mode,
+        "delete_policy": build_delete_policy(config.delete_mode),
         "cron_expression": config.cron_expression,
         "enabled": config.enabled,
         "created_at": config.created_at.isoformat() if config.created_at else None,

--- a/backend/core/sync/delete_policy.py
+++ b/backend/core/sync/delete_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+DELETE_POLICY_VERSION = "2026-03-10"
+
+
+class DeleteMode(str, Enum):
+    OBSERVE_ONLY = "observe_only"
+    APPROVAL_REQUIRED = "approval_required"
+    SOFT_DELETE = "soft_delete"
+
+
+_POLICY_DEFINITIONS: dict[DeleteMode, dict[str, Any]] = {
+    DeleteMode.OBSERVE_ONLY: {
+        "label": "Observe Only",
+        "supported": True,
+        "destructive": False,
+        "requires_approval": False,
+        "summary": "Record delete intent in diff and history only. Leave the Dify app untouched.",
+        "rollback_requirement": "No rollback path is required because no delete is executed.",
+        "approval_requirement": "None.",
+    },
+    DeleteMode.APPROVAL_REQUIRED: {
+        "label": "Approval Required",
+        "supported": True,
+        "destructive": False,
+        "requires_approval": True,
+        "summary": "Record delete intent and block execution until an explicit operator approval workflow exists.",
+        "rollback_requirement": "Capture the current Dify app snapshot before any future destructive delete flow is approved.",
+        "approval_requirement": "An explicit operator approval artifact must exist before delete execution can be enabled.",
+    },
+    DeleteMode.SOFT_DELETE: {
+        "label": "Soft Delete",
+        "supported": False,
+        "destructive": True,
+        "requires_approval": True,
+        "summary": "Reserved for a future archive or tombstone flow. It is intentionally blocked in the current product.",
+        "rollback_requirement": "A reversible archive and restore path must exist before soft-delete can be enabled.",
+        "approval_requirement": "Approval plus restore automation are mandatory before enablement.",
+    },
+}
+
+_DELETE_INTENT_STATUS = {
+    DeleteMode.OBSERVE_ONLY: "observed",
+    DeleteMode.APPROVAL_REQUIRED: "approval_pending",
+    DeleteMode.SOFT_DELETE: "blocked",
+}
+
+
+def normalize_delete_mode(mode: str | DeleteMode | None) -> DeleteMode:
+    if isinstance(mode, DeleteMode):
+        return mode
+    try:
+        return DeleteMode(str(mode or DeleteMode.OBSERVE_ONLY.value))
+    except ValueError:
+        return DeleteMode.OBSERVE_ONLY
+
+
+def ensure_delete_mode_supported(mode: str | DeleteMode | None) -> DeleteMode:
+    normalized = normalize_delete_mode(mode)
+    if normalized == DeleteMode.SOFT_DELETE:
+        raise ValueError(
+            "soft_delete is defined but intentionally unsupported until a reversible archive and restore path exists. "
+            "Use observe_only or approval_required."
+        )
+    return normalized
+
+
+def build_delete_policy(mode: str | DeleteMode | None, *, intent_status: str | None = None) -> dict[str, Any]:
+    normalized = normalize_delete_mode(mode)
+    policy = {
+        "mode": normalized.value,
+        "version": DELETE_POLICY_VERSION,
+        **_POLICY_DEFINITIONS[normalized],
+    }
+    if intent_status is not None:
+        policy["intent_status"] = intent_status
+    return policy
+
+
+def delete_intent_status(mode: str | DeleteMode | None) -> str:
+    return _DELETE_INTENT_STATUS[normalize_delete_mode(mode)]

--- a/backend/core/sync/sync_engine.py
+++ b/backend/core/sync/sync_engine.py
@@ -13,6 +13,7 @@ from core.dify.db_reader import DifyDbReader
 from core.engine.conversion_service import ConversionService
 from core.security.redaction import build_database_ref, sanitize_exception
 from core.sync.conflict_resolver import ConflictResolver, ConflictStrategy
+from core.sync.delete_policy import build_delete_policy, delete_intent_status
 from core.sync.diff_detector import DiffDetector
 from db.models import MigrationTask, SyncConfig, SyncHistory
 
@@ -72,7 +73,7 @@ class SyncEngine:
             target_apps_by_id = {str(app.get("app_id") or ""): app for app in target_apps if app.get("app_id")}
             target_names = self._index_target_names(target_apps)
 
-            items.extend(self._collect_delete_gaps(mappings, source_ids, target_apps_by_id, summary))
+            items.extend(self._collect_delete_gaps(config, mappings, source_ids, target_apps_by_id, summary))
 
             for workflow in source_workflows:
                 source_id = self._workflow_id(workflow)
@@ -245,7 +246,7 @@ class SyncEngine:
         target_apps_by_id = {str(app.get("app_id") or ""): app for app in target_apps if app.get("app_id")}
         target_names = self._index_target_names(target_apps)
 
-        items.extend(self._collect_delete_gaps(mappings, source_ids, target_apps_by_id, summary))
+        items.extend(self._collect_delete_gaps(config, mappings, source_ids, target_apps_by_id, summary))
 
         source_snapshots: dict[str, dict[str, Any]] = {}
         target_snapshots: dict[str, dict[str, Any]] = {}
@@ -391,6 +392,7 @@ class SyncEngine:
 
         return {
             "config_id": config.id,
+            "delete_policy": build_delete_policy(config.delete_mode),
             "summary": summary,
             "items": items,
             "status": self._derive_status(summary),
@@ -538,6 +540,9 @@ class SyncEngine:
     def serialize_history(history: SyncHistory, *, include_items: bool = False) -> dict[str, Any]:
         payload = history.conflicts_resolved or {}
         summary = payload.get("summary") or SyncEngine._empty_summary()
+        audit_payload = payload.get("audit")
+        if not isinstance(audit_payload, dict):
+            audit_payload = None
         data = {
             "id": str(history.id),
             "sync_config_id": history.sync_config_id,
@@ -553,7 +558,8 @@ class SyncEngine:
                 **SyncEngine._empty_summary(),
                 **summary,
             },
-            "audit": payload.get("audit") or None,
+            "delete_policy": audit_payload.get("delete_policy") if audit_payload else None,
+            "audit": audit_payload,
         }
         if include_items:
             data["items"] = payload.get("items") or []
@@ -564,6 +570,8 @@ class SyncEngine:
         return {
             "config_name": config.name,
             "sync_mode": config.sync_mode,
+            "delete_mode": config.delete_mode,
+            "delete_policy": build_delete_policy(config.delete_mode),
             "cron_expression": config.cron_expression,
             "trigger_type": trigger_type,
             "source_db": build_database_ref(config.coze_db_url),
@@ -580,6 +588,8 @@ class SyncEngine:
         payload = dict(audit) if isinstance(audit, dict) else {}
         payload.setdefault("config_name", config.name)
         payload.setdefault("sync_mode", config.sync_mode)
+        payload.setdefault("delete_mode", config.delete_mode)
+        payload.setdefault("delete_policy", build_delete_policy(config.delete_mode))
         payload.setdefault("cron_expression", config.cron_expression)
         payload.setdefault("trigger_type", trigger_type)
         payload.setdefault("source_db", build_database_ref(config.coze_db_url))
@@ -654,8 +664,9 @@ class SyncEngine:
         message: str,
         target_app_id: str | None = None,
         conversion_id: str | None = None,
+        delete_policy: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        return {
+        item = {
             "action": action,
             "status": status,
             "source_workflow_id": source_workflow_id,
@@ -664,6 +675,9 @@ class SyncEngine:
             "conversion_id": conversion_id,
             "message": message,
         }
+        if delete_policy is not None:
+            item["delete_policy"] = delete_policy
+        return item
 
     @staticmethod
     def _workflow_id(workflow: dict[str, Any]) -> str:
@@ -804,18 +818,28 @@ class SyncEngine:
     @classmethod
     def _collect_delete_gaps(
         cls,
+        config: SyncConfig,
         mappings: dict[str, dict[str, Any]],
         source_ids: set[str],
         target_apps_by_id: dict[str, dict[str, Any]],
         summary: dict[str, int],
     ) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
+        delete_policy = build_delete_policy(
+            config.delete_mode,
+            intent_status=delete_intent_status(config.delete_mode),
+        )
         for source_id, mapping in mappings.items():
             if source_id in source_ids:
                 continue
             target_app_id = mapping["app_id"]
             if target_app_id not in target_apps_by_id:
                 continue
+            message = (
+                "Delete intent recorded in observe-only mode. The existing Dify app was left untouched."
+                if config.delete_mode == "observe_only"
+                else "Delete intent recorded and blocked pending operator approval. The existing Dify app was left untouched."
+            )
             summary["unsupported"] += 1
             items.append(
                 cls._result_item(
@@ -824,7 +848,8 @@ class SyncEngine:
                     source_workflow_id=source_id,
                     source_workflow_name=str(mapping.get("source_workflow_name") or source_id),
                     target_app_id=target_app_id,
-                    message="Delete sync is not supported in the manual sync MVP. The existing Dify app was left untouched.",
+                    message=message,
+                    delete_policy=delete_policy,
                 )
             )
         return items

--- a/backend/db/alembic/versions/20260310_02_add_delete_mode_to_sync_config.py
+++ b/backend/db/alembic/versions/20260310_02_add_delete_mode_to_sync_config.py
@@ -1,0 +1,29 @@
+"""Add delete_mode to sync configs.
+
+Revision ID: 20260310_02
+Revises: 20260309_01
+Create Date: 2026-03-10 10:30:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260310_02"
+down_revision = "20260309_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sync_configs",
+        sa.Column("delete_mode", sa.String(length=50), nullable=False, server_default="observe_only"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sync_configs", "delete_mode")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -19,6 +19,7 @@ class SyncConfig(Base):
     coze_db_url: Mapped[str] = mapped_column(String(500))
     dify_db_url: Mapped[str] = mapped_column(String(500))
     sync_mode: Mapped[str] = mapped_column(String(50), default="manual")
+    delete_mode: Mapped[str] = mapped_column(String(50), default="observe_only")
     cron_expression: Mapped[str | None] = mapped_column(String(100), nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -23,10 +23,12 @@ def test_alembic_upgrade_and_downgrade_round_trip(tmp_path) -> None:
 
     engine = create_engine(db_url, connect_args={"check_same_thread": False})
     upgraded_tables = set(inspect(engine).get_table_names())
+    sync_config_columns = {column["name"] for column in inspect(engine).get_columns("sync_configs")}
     engine.dispose()
 
     assert PROJECT_TABLES.issubset(upgraded_tables)
     assert "alembic_version" in upgraded_tables
+    assert "delete_mode" in sync_config_columns
 
     command.downgrade(config, "base")
 

--- a/backend/tests/test_sync_api.py
+++ b/backend/tests/test_sync_api.py
@@ -162,6 +162,7 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
         "unsupported": 0,
         "conflicts": 0,
     }
+    assert execute_data["delete_policy"]["mode"] == "observe_only"
     assert execute_data["items"][0]["status"] == "created"
     assert execute_data["items"][0]["target_app_id"] == "created-app"
 
@@ -184,6 +185,8 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
     assert config_payload["dify_db"]["display_url"] == "postgresql://***@dify.test/app"
     assert config_payload["has_stored_coze_db_url"] is True
     assert config_payload["has_stored_dify_db_url"] is True
+    assert config_payload["delete_mode"] == "observe_only"
+    assert config_payload["delete_policy"]["supported"] is True
 
     test_response = client.post(
         "/api/v1/sync/config/test",
@@ -205,6 +208,7 @@ def test_sync_execute_endpoint_persists_history_and_exposes_detail(tmp_path, mon
     assert histories[0].workflows_synced == 1
     assert histories[0].conflicts_resolved["audit"]["source_db"]["display_url"] == "postgresql://***@coze.test/app"
     assert histories[0].conflicts_resolved["audit"]["target_db"]["display_url"] == "postgresql://***@dify.test/app"
+    assert histories[0].conflicts_resolved["audit"]["delete_policy"]["mode"] == "observe_only"
     assert len(tasks) == 1
     assert tasks[0].sync_config_id == histories[0].sync_config_id
 
@@ -225,6 +229,17 @@ def test_sync_schedule_diff_and_conflict_endpoints_are_wired(tmp_path, monkeypat
         def preview_diff(self, db, config):
             return {
                 "config_id": config.id,
+                "delete_policy": {
+                    "mode": "observe_only",
+                    "label": "Observe Only",
+                    "supported": True,
+                    "destructive": False,
+                    "requires_approval": False,
+                    "summary": "Record delete intent only.",
+                    "rollback_requirement": "None.",
+                    "approval_requirement": "None.",
+                    "version": "2026-03-10",
+                },
                 "status": "partial",
                 "summary": {
                     "created": 1,
@@ -434,6 +449,37 @@ def test_restore_schedules_registers_only_enabled_scheduled_configs(tmp_path) ->
     assert len(scheduled_jobs) == 1
     assert restored_jobs[0]["config_id"] == scheduled_jobs[0]["config_id"]
     assert restored_jobs[0]["cron_expression"] == "0 3 * * *"
+
+
+def test_sync_config_rejects_soft_delete_until_rollback_exists(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-delete-policy.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    def override_get_db():
+        with session_factory() as db:
+            yield db
+
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api/v1")
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/sync/config",
+        json={
+            "name": "Blocked Delete Policy",
+            "coze_db_url": "postgresql://coze.test/app",
+            "dify_db_url": "postgresql://dify.test/app",
+            "delete_mode": "soft_delete",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "soft_delete is defined but intentionally unsupported" in response.json()["detail"]
 
 
 def test_app_startup_invokes_schedule_restore(monkeypatch) -> None:

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -101,6 +101,32 @@ class PreviewDifyReader:
         return self.workflows.get(app_id)
 
 
+class EmptyCozeReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_workflows(self) -> list[dict[str, str]]:
+        return []
+
+    def read_workflow(self, workflow_id: str) -> dict[str, object] | None:
+        return None
+
+
+class DeletePreviewDifyReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_apps(self) -> list[dict[str, str]]:
+        return [
+            {"app_id": "app-delete", "name": "Deleted Flow"},
+        ]
+
+    def read_workflow(self, app_id: str) -> dict[str, object] | None:
+        if app_id != "app-delete":
+            return None
+        return {"app_id": app_id, "graph": {"nodes": [], "edges": []}, "features": {}}
+
+
 class FakeConversionService:
     def __init__(self) -> None:
         self.write_calls: list[tuple[str, str | None, str | None]] = []
@@ -248,6 +274,7 @@ def test_execute_sync_persists_create_and_update_results(tmp_path) -> None:
         "unsupported": 0,
         "conflicts": 0,
     }
+    assert result["delete_policy"]["mode"] == "observe_only"
     assert len(result["items"]) == 2
     assert {item["status"] for item in result["items"]} == {"created", "updated"}
     assert len(histories) == 1
@@ -349,6 +376,57 @@ def test_preview_diff_detects_create_update_skip_and_conflict_without_persisting
         "wf-conflict",
     }
     assert len(task_count) == 2
+
+
+def test_preview_diff_records_delete_intent_under_selected_policy(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-delete-preview.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    sync_engine = SyncEngine(
+        ConversionService(),
+        coze_reader_factory=EmptyCozeReader,
+        dify_reader_factory=DeletePreviewDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Delete Preview",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+            delete_mode="approval_required",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        db.add(
+            MigrationTask(
+                sync_config_id=config.id,
+                source_type="database",
+                source_workflow_id="wf-delete",
+                source_workflow_name="Deleted Flow",
+                status="written",
+                ir_snapshot={"write_result": {"app_id": "app-delete", "mode": "create"}},
+                dify_dsl="workflow: {}\n",
+                report={},
+                completed_at=_utcnow(),
+            )
+        )
+        db.commit()
+
+        result = sync_engine.preview_diff(db, config)
+
+    assert result["status"] == "partial"
+    assert result["summary"]["unsupported"] == 1
+    assert result["delete_policy"]["mode"] == "approval_required"
+    assert result["items"][0]["action"] == "delete"
+    assert result["items"][0]["status"] == "unsupported"
+    assert result["items"][0]["delete_policy"]["mode"] == "approval_required"
+    assert result["items"][0]["delete_policy"]["intent_status"] == "approval_pending"
 
 
 def test_resolve_conflict_source_wins_updates_history_and_persists_resolution(tmp_path) -> None:

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,12 @@ Safety behavior:
 
 Create or update sync configuration (source DB + target DB connection info).
 
+Request supports `delete_mode` with:
+
+- `observe_only` (default)
+- `approval_required`
+- `soft_delete` (defined but rejected until rollback support exists)
+
 ### `GET /sync/config`
 
 Get current sync configuration.
@@ -166,6 +172,7 @@ Safety behavior:
 
 - stored source/target DB URLs are returned as redacted references such as `postgresql://***@host/db`
 - blank DB URL fields on follow-up save/run requests keep the persisted value for the referenced `config_id`
+- responses include the active `delete_policy` so operators can see rollback and approval requirements
 
 ### `POST /sync/config/test`
 
@@ -210,6 +217,9 @@ Cancel scheduled sync for a persisted config.
 ### `POST /sync/diff`
 
 Compare source/target differences without executing sync.
+
+Diff payloads include the active `delete_policy`, and delete-gap items carry structured policy metadata rather
+than a generic unsupported message alone.
 
 ### `POST /sync/conflicts/{id}/resolve`
 

--- a/docs/delete-sync-policy.md
+++ b/docs/delete-sync-policy.md
@@ -1,0 +1,43 @@
+# Delete Sync Policy
+
+## Goal
+
+Define how sync should behave when a previously synced Coze workflow disappears from the source system while a mapped Dify app still exists.
+
+Current scope is governance and auditability. No destructive delete is executed by the product today.
+
+## Supported Modes
+
+| Mode | Supported | Runtime Behavior | Approval Requirement | Rollback Requirement |
+|------|-----------|------------------|----------------------|----------------------|
+| `observe_only` | Yes | Record delete intent in diff preview and sync history. Leave the Dify app untouched. | None | None, because no delete occurs. |
+| `approval_required` | Yes | Record delete intent and explicitly block execution until an operator approval workflow exists. Leave the Dify app untouched. | Explicit operator approval artifact required before any future delete execution is enabled. | Capture the current Dify app snapshot before any destructive flow is ever approved. |
+| `soft_delete` | No | Intentionally blocked. The API rejects this mode today. | Would require approval plus a reversible archive or tombstone workflow. | A tested archive and restore path must exist before enablement. |
+
+## Representation In Product Surfaces
+
+- Sync config persists `delete_mode` and returns a structured `delete_policy` payload.
+- `POST /sync/diff` returns the active `delete_policy` at the top level.
+- Delete-gap items in diff output and sync history include `delete_policy.intent_status`:
+  - `observed` for `observe_only`
+  - `approval_pending` for `approval_required`
+  - `blocked` for any future unsupported destructive mode
+- Sync history audit stores the configured delete policy alongside source and target database references.
+
+## Safety Rules
+
+- The product does not delete or archive Dify apps automatically.
+- Delete gaps continue to appear as non-success outcomes in sync summaries so operators must review them.
+- Destructive delete support cannot be added without:
+  - explicit operator approval capture
+  - persisted target snapshot or equivalent rollback artifact
+  - documented restore procedure
+  - audit trail proving who approved and when execution occurred
+
+## Rollout Decision
+
+`observe_only` remains the default.
+
+`approval_required` is supported as a governance mode for teams that want delete intent recorded with stronger process language, but it still performs no destructive action.
+
+`soft_delete` remains intentionally unsupported until rollback and restore guarantees are implemented end to end.

--- a/frontend/src/components/diff/SyncVisualBoard.tsx
+++ b/frontend/src/components/diff/SyncVisualBoard.tsx
@@ -134,6 +134,15 @@ function SyncRunCard({
 
       <div className="change-item__note">{item.message}</div>
 
+      {item.delete_policy ? (
+        <div className="change-item__note change-item__note--warning">
+          {item.delete_policy.label} • {item.delete_policy.summary}
+          <div style={{ marginTop: 4 }}>
+            Rollback: {item.delete_policy.rollback_requirement}
+          </div>
+        </div>
+      ) : null}
+
       {item.resolution ? (
         <div className="change-item__note change-item__note--info">
           {item.resolution.status} • {item.resolution.strategy}

--- a/frontend/src/components/sync/DeletePolicyNotice.tsx
+++ b/frontend/src/components/sync/DeletePolicyNotice.tsx
@@ -1,0 +1,31 @@
+import type { SyncDeletePolicy } from "../../types/sync";
+
+export default function DeletePolicyNotice({
+  title,
+  policy,
+}: {
+  title: string;
+  policy: SyncDeletePolicy;
+}) {
+  const tone = policy.supported ? "alert--info" : "alert--warning";
+
+  return (
+    <div className={`alert ${tone}`}>
+      <strong>{title}</strong>
+      <div style={{ marginTop: 6 }}>
+        {policy.label} • {policy.summary}
+      </div>
+      <div style={{ marginTop: 6, fontSize: "0.78rem" }}>
+        Rollback: {policy.rollback_requirement}
+      </div>
+      <div style={{ marginTop: 4, fontSize: "0.78rem" }}>
+        Approval: {policy.approval_requirement}
+      </div>
+      {policy.intent_status ? (
+        <div style={{ marginTop: 4, fontSize: "0.78rem", fontFamily: "var(--font-mono)" }}>
+          Intent status: {policy.intent_status}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import SyncVisualBoard from "../components/diff/SyncVisualBoard";
+import DeletePolicyNotice from "../components/sync/DeletePolicyNotice";
 import SyncHistoryTable from "../components/sync/SyncHistoryTable";
 import { getSyncHistoryDetail, listSyncHistory } from "../api/sync";
 import type { SyncHistoryEntry, SyncRunDetail } from "../types/sync";
@@ -146,6 +147,12 @@ export default function SyncHistoryPage() {
                   {selectedRun.audit.last_error ? (
                     <div className="alert alert--error">{selectedRun.audit.last_error}</div>
                   ) : null}
+                </div>
+              ) : null}
+
+              {selectedRun.delete_policy ? (
+                <div style={{ marginTop: 18 }}>
+                  <DeletePolicyNotice title="Run Delete Policy" policy={selectedRun.delete_policy} />
                 </div>
               ) : null}
 

--- a/frontend/src/pages/SyncPage.tsx
+++ b/frontend/src/pages/SyncPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import SyncVisualBoard from "../components/diff/SyncVisualBoard";
+import DeletePolicyNotice from "../components/sync/DeletePolicyNotice";
 import SyncHistoryTable from "../components/sync/SyncHistoryTable";
 import {
   cancelSyncSchedule,
@@ -19,6 +20,8 @@ import type {
   SyncConfigInput,
   SyncConflictStrategy,
   SyncConnectionResult,
+  SyncDeleteMode,
+  SyncDeletePolicy,
   SyncDiffPreview,
   SyncHistoryEntry,
   SyncRunDetail,
@@ -32,6 +35,7 @@ const DEFAULT_FORM: SyncConfigInput = {
   coze_db_url: "",
   dify_db_url: "",
   sync_mode: "manual",
+  delete_mode: "observe_only",
   cron_expression: "",
 };
 
@@ -42,6 +46,42 @@ const EMPTY_SUMMARY: SyncSummary = {
   skipped: 0,
   unsupported: 0,
   conflicts: 0,
+};
+
+const DELETE_POLICY_PRESETS: Record<SyncDeleteMode, SyncDeletePolicy> = {
+  observe_only: {
+    mode: "observe_only",
+    version: "2026-03-10",
+    label: "Observe Only",
+    supported: true,
+    destructive: false,
+    requires_approval: false,
+    summary: "Record delete intent in diff and history only. Leave the Dify app untouched.",
+    rollback_requirement: "No rollback path is required because no delete is executed.",
+    approval_requirement: "None.",
+  },
+  approval_required: {
+    mode: "approval_required",
+    version: "2026-03-10",
+    label: "Approval Required",
+    supported: true,
+    destructive: false,
+    requires_approval: true,
+    summary: "Record delete intent and block execution until an explicit operator approval workflow exists.",
+    rollback_requirement: "Capture the current Dify app snapshot before any future destructive delete flow is approved.",
+    approval_requirement: "An explicit operator approval artifact must exist before delete execution can be enabled.",
+  },
+  soft_delete: {
+    mode: "soft_delete",
+    version: "2026-03-10",
+    label: "Soft Delete",
+    supported: false,
+    destructive: true,
+    requires_approval: true,
+    summary: "Reserved for a future archive or tombstone flow. It is intentionally blocked in the current product.",
+    rollback_requirement: "A reversible archive and restore path must exist before soft-delete can be enabled.",
+    approval_requirement: "Approval plus restore automation are mandatory before enablement.",
+  },
 };
 
 export default function SyncPage() {
@@ -306,6 +346,11 @@ export default function SyncPage() {
     : null;
   const runSummary = selectedRun?.summary || EMPTY_SUMMARY;
   const previewSummary = diffPreview?.summary || EMPTY_SUMMARY;
+  const currentDeleteMode = form.delete_mode || "observe_only";
+  const configuredDeletePolicy =
+    storedConfig?.delete_mode === currentDeleteMode && storedConfig.delete_policy
+      ? storedConfig.delete_policy
+      : DELETE_POLICY_PRESETS[currentDeleteMode];
 
   return (
     <div className="fade-in">
@@ -381,6 +426,28 @@ export default function SyncPage() {
                 Use standard cron format in UTC. Example: `0 3 * * *`
               </div>
             </div>
+
+            <div>
+              <label className="label">Delete Policy</label>
+              <select
+                className="input"
+                value={currentDeleteMode}
+                onChange={(e) => updateField("delete_mode", e.target.value)}
+              >
+                <option value="observe_only">Observe Only</option>
+                <option value="approval_required">Approval Required</option>
+                <option value="soft_delete" disabled>
+                  Soft Delete (Blocked)
+                </option>
+              </select>
+              <div style={{ marginTop: 6, fontSize: "0.78rem", color: "var(--c-text-tertiary)" }}>
+                Defines how delete gaps are represented when a previously synced Coze workflow disappears.
+              </div>
+            </div>
+          </div>
+
+          <div style={{ marginTop: 20 }}>
+            <DeletePolicyNotice title="Configured Delete Policy" policy={configuredDeletePolicy} />
           </div>
 
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 20 }}>
@@ -535,6 +602,10 @@ export default function SyncPage() {
               Preview status: <strong>{diffPreview.status}</strong> • Config {diffPreview.config_id}
             </div>
 
+            <div style={{ marginTop: 16 }}>
+              <DeletePolicyNotice title="Delete Gap Policy" policy={diffPreview.delete_policy} />
+            </div>
+
             <div style={{ marginTop: 18 }}>
               <SyncVisualBoard
                 items={diffPreview.items}
@@ -582,6 +653,7 @@ function toInput(config: SyncConfig): SyncConfigInput {
     coze_db_url: "",
     dify_db_url: "",
     sync_mode: config.sync_mode,
+    delete_mode: config.delete_mode,
     cron_expression: config.cron_expression || "",
   };
 }
@@ -667,6 +739,10 @@ function RunAuditPanel({ audit }: { audit: NonNullable<SyncRunDetail["audit"]> }
           <strong>Last error</strong>
           <div style={{ marginTop: 4 }}>{audit.last_error}</div>
         </div>
+      ) : null}
+
+      {audit.delete_policy ? (
+        <DeletePolicyNotice title="Run Delete Policy" policy={audit.delete_policy} />
       ) : null}
 
       {failures.length > 1 ? (

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -3,6 +3,20 @@ import type { DatabaseTargetRef } from "./audit";
 export type SyncMode = "manual" | "scheduled";
 export type SyncRunStatus = "completed" | "partial" | "failed" | "running";
 export type SyncConflictStrategy = "source_wins" | "target_wins" | "manual";
+export type SyncDeleteMode = "observe_only" | "approval_required" | "soft_delete";
+
+export interface SyncDeletePolicy {
+  mode: SyncDeleteMode;
+  version: string;
+  label: string;
+  supported: boolean;
+  destructive: boolean;
+  requires_approval: boolean;
+  summary: string;
+  rollback_requirement: string;
+  approval_requirement: string;
+  intent_status?: "observed" | "approval_pending" | "blocked";
+}
 
 export interface SyncConfig {
   id: number;
@@ -13,6 +27,8 @@ export interface SyncConfig {
   has_stored_coze_db_url: boolean;
   has_stored_dify_db_url: boolean;
   sync_mode: SyncMode;
+  delete_mode: SyncDeleteMode;
+  delete_policy: SyncDeletePolicy;
   cron_expression: string | null;
   enabled: boolean;
   created_at: string | null;
@@ -26,6 +42,7 @@ export interface SyncConfigInput {
   coze_db_url: string;
   dify_db_url: string;
   sync_mode?: SyncMode;
+  delete_mode?: SyncDeleteMode;
   cron_expression?: string | null;
 }
 
@@ -66,6 +83,7 @@ export interface SyncRunItem {
   target_app_id: string | null;
   conversion_id: string | null;
   message: string;
+  delete_policy?: SyncDeletePolicy;
   resolution?: SyncResolution;
 }
 
@@ -85,6 +103,8 @@ export interface SyncStatus {
 export interface SyncRunAudit {
   config_name?: string;
   sync_mode?: string;
+  delete_mode?: SyncDeleteMode;
+  delete_policy?: SyncDeletePolicy | null;
   cron_expression?: string | null;
   trigger_type?: string;
   source_db?: DatabaseTargetRef | null;
@@ -112,6 +132,7 @@ export interface SyncHistoryEntry {
   workflows_failed: number;
   conflicts_count: number;
   summary: SyncSummary;
+  delete_policy?: SyncDeletePolicy | null;
   audit?: SyncRunAudit | null;
 }
 
@@ -122,6 +143,7 @@ export interface SyncRunDetail extends SyncHistoryEntry {
 export interface SyncDiffPreview {
   config_id: number;
   status: Exclude<SyncRunStatus, "running">;
+  delete_policy: SyncDeletePolicy;
   summary: SyncSummary;
   items: SyncRunItem[];
 }


### PR DESCRIPTION
## Summary
- add a persisted delete policy to sync configs, audit trails, diff previews, and delete-gap items
- reject unsupported `soft_delete` mode until rollback and restore guarantees exist
- document the supported modes and show policy details in the sync UI

## Testing
- ./scripts/ci-local.sh
- cd frontend && npx tsc --noEmit
- cd frontend && npm run build

Closes #27