### PR TITLE
Fix invalid Dify code node output types for array outputs

### DIFF
--- a/backend/core/dify/node_generators/code.py
+++ b/backend/core/dify/node_generators/code.py
@@ -13,7 +13,11 @@ _TYPE_MAP = {
     IRVariableType.NUMBER: "number",
     IRVariableType.BOOLEAN: "boolean",
     IRVariableType.OBJECT: "object",
-    IRVariableType.ARRAY: "array[any]",
+    # Dify code nodes require concrete array segment types. Generic arrays degrade to object arrays.
+    IRVariableType.ARRAY: "array[object]",
+    IRVariableType.ARRAY_STRING: "array[string]",
+    IRVariableType.ARRAY_NUMBER: "array[number]",
+    IRVariableType.ARRAY_OBJECT: "array[object]",
     IRVariableType.ANY: "string",
 }
 

--- a/backend/tests/test_code_node_generator.py
+++ b/backend/tests/test_code_node_generator.py
@@ -1,0 +1,29 @@
+from core.dify.node_generators.code import CodeNodeGenerator
+from core.ir.models import IRNode, IRPosition, IRVariable
+from core.ir.types import IRNodeType, IRVariableType
+
+
+def test_code_node_outputs_use_dify_supported_array_types() -> None:
+    ir_node = IRNode(
+        id="code-node",
+        node_type=IRNodeType.CODE,
+        title="Code Node",
+        position=IRPosition(),
+        outputs=[
+            IRVariable(name="arr_any", var_type=IRVariableType.ARRAY),
+            IRVariable(name="arr_string", var_type=IRVariableType.ARRAY_STRING),
+            IRVariable(name="arr_number", var_type=IRVariableType.ARRAY_NUMBER),
+            IRVariable(name="arr_object", var_type=IRVariableType.ARRAY_OBJECT),
+            IRVariable(name="fallback", var_type=IRVariableType.ANY),
+        ],
+    )
+
+    payload = CodeNodeGenerator().generate(ir_node, var_transformer=None)
+
+    assert payload["outputs"] == {
+        "arr_any": {"type": "array[object]"},
+        "arr_string": {"type": "array[string]"},
+        "arr_number": {"type": "array[number]"},
+        "arr_object": {"type": "array[object]"},
+        "fallback": {"type": "string"},
+    }


### PR DESCRIPTION
## Summary
- map generic code-node arrays to Dify-supported `array[object]` instead of invalid `array[any]`
- add explicit output mappings for typed array variants on code nodes
- add regression coverage for code-node output type generation

## Testing
- pytest -q tests/test_code_node_generator.py tests/test_conversion_service.py tests/test_composite_graph.py
- ./scripts/ci-local.sh

Closes #34