### PR TITLE
Enforce strict supported subset gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@
 |---------|--------|-------------|
 | 🔄 **Workflow Conversion** | ✅ Verified | Coze JSON/YAML → IR → Dify graph / DSL |
 | 📂 **File Import + DSL Export** | ✅ Verified | Upload local workflow file and export generated DSL |
-| 🗺️ **Node Mapping** | 🟡 Partial | Main node types covered, but not every Coze construct is lossless |
+| 🗺️ **Node Mapping** | 🟡 Strict Subset | Runtime only emits DSL for the verified supported subset; partial and unmappable nodes are blocked |
 | 🔀 **Variable Transform** | 🟡 Partial | Common `BlockInputReference` cases work; edge cases still exist |
-| 📋 **Conversion Report** | ✅ Verified | Mapping stats, warnings, unmappable nodes |
-| 🗄️ **Direct Dify DB Write** | 🟡 Experimental | Backend writer works for local migration tests, UI/API flow is not fully wired |
+| 📋 **Conversion Report** | ✅ Verified | Mapping stats plus strict-subset support status and blocking issues |
+| 🗄️ **Direct Dify DB Write** | 🟡 Guarded | Only allowed for conversions inside the strict supported subset |
 | 📊 **Visual Diff** | 🟡 Basic | Current UI shows report + mapping table, not a full graph diff |
 | 🔍 **Platform Browse** | 🚧 In Progress | Connection UI exists, workflow selection flow is not completed |
 | 🛠️ **Dev Mode** | 🟡 Experimental | Local service detection exists, but one-click workflow operations are limited |
@@ -50,12 +50,24 @@
 
 ## 📌 Current Status
 
-- **Verified path**: file-based Coze workflow conversion into Dify graph / DSL.
+- **Verified path**: file-based Coze workflow conversion into Dify graph / DSL for the strict supported subset.
 - **Verified in local testing**: migrated workflow can be written into a local Dify PostgreSQL instance and opened in Dify.
+- **Strict runtime policy**: partial and unmappable nodes are blocked instead of emitting best-effort DSL.
 - **Partially built**: platform browse, dev mode helpers, and direct-write UI.
 - **Not production-ready yet**: incremental sync, migration history persistence, and several API/database import flows.
 
 If you are evaluating the project, treat it as a working migration core with unfinished product surface area.
+
+## ✅ Strict Supported Subset
+
+The current runtime contract is intentionally conservative. Automatic DSL generation is admitted only for:
+
+- Entry (`start`)
+- Exit (`end`)
+- OutputEmitter (`answer`)
+- Comment (`skipped safely`)
+
+Everything else that is still marked as partial, mode-change, or unmappable in the 42-type mapping table is blocked at conversion time. See [`docs/supported-subset.md`](docs/supported-subset.md).
 
 ## 🏗️ Architecture
 
@@ -141,7 +153,7 @@ Some endpoints below exist in the API surface but are not all fully wired in the
 | `POST` | `/api/v1/coze/upload` | Upload Coze workflow file |
 | `POST` | `/api/v1/convert` | Execute conversion |
 | `GET`  | `/api/v1/convert/{id}/dsl` | Download Dify DSL |
-| `POST` | `/api/v1/convert/{id}/write-to-dify` | Write converted DSL directly to Dify PostgreSQL |
+| `POST` | `/api/v1/convert/{id}/write-to-dify` | Write converted DSL directly to Dify PostgreSQL (blocked conversions are rejected) |
 
 ### Sync
 
@@ -177,7 +189,7 @@ Delete gaps are governed by an explicit policy layer; see [`docs/delete-sync-pol
 
 ## 🗺️ Node Mapping (42 types)
 
-The mapping table is the target design. Actual support quality varies by node type, and several mappings are still partial.
+The mapping table is the design target. Runtime enforcement is stricter: only the subset documented in [`docs/supported-subset.md`](docs/supported-subset.md) is currently allowed to emit DSL.
 
 | Coze Node | Dify Node | Level |
 |-----------|-----------|-------|
@@ -200,7 +212,7 @@ The mapping table is the target design. Actual support quality varies by node ty
 | Continue | — | 🔴 Unmappable |
 | Comment | — | ⚪ Skipped |
 
-> See the full 42-type mapping in [`docs/node-mapping.md`](docs/node-mapping.md). Architecture details in [`docs/architecture.md`](docs/architecture.md). API reference in [`docs/api.md`](docs/api.md). Delete policy guide in [`docs/delete-sync-policy.md`](docs/delete-sync-policy.md). Dev Mode guide in [`docs/dev-mode.md`](docs/dev-mode.md).
+> See the full 42-type mapping in [`docs/node-mapping.md`](docs/node-mapping.md). Strict runtime policy is documented in [`docs/supported-subset.md`](docs/supported-subset.md). Architecture details in [`docs/architecture.md`](docs/architecture.md). API reference in [`docs/api.md`](docs/api.md). Delete policy guide in [`docs/delete-sync-policy.md`](docs/delete-sync-policy.md). Dev Mode guide in [`docs/dev-mode.md`](docs/dev-mode.md).
 
 ## 📁 Project Structure
 
@@ -213,6 +225,7 @@ coze2dify/
 ├── docs/                      # Documentation
 │   ├── architecture.md        #   IR pipeline design
 │   ├── node-mapping.md        #   42-type mapping reference
+│   ├── supported-subset.md    #   strict runtime support policy
 │   ├── api.md                 #   REST API reference
 │   └── dev-mode.md            #   Dev mode guide
 │

--- a/backend/core/coze/parser.py
+++ b/backend/core/coze/parser.py
@@ -208,6 +208,19 @@ class CozeParser:
             return inputs, outputs, config
 
         coze_inputs = node.data.get("inputs", {})
+        start_outputs = node.data.get("outputs", [])
+
+        if node.type == "1":
+            for output_data in start_outputs:
+                inputs.append(
+                    IRVariable(
+                        name=output_data.get("name", ""),
+                        var_type=_VAR_TYPE_MAP.get(output_data.get("type", "string"), IRVariableType.ANY),
+                        required=bool(output_data.get("required", False)),
+                        description=str(output_data.get("description") or ""),
+                        default_value=output_data.get("default"),
+                    )
+                )
 
         for param_data in coze_inputs.get("inputParameters", []):
             name = param_data.get("name", "")

--- a/backend/core/engine/conversion_service.py
+++ b/backend/core/engine/conversion_service.py
@@ -130,6 +130,11 @@ class ConversionService:
         target_db_url = db_url or settings.dify_database_url
         if not target_db_url:
             raise ValueError("Dify database URL is required")
+        report = task.report or {}
+        if not bool(report.get("supported", True)):
+            blocking_issues = report.get("blocking_issues") or []
+            detail = blocking_issues[0] if blocking_issues else "This workflow is outside the strict supported subset."
+            raise ValueError(detail)
 
         snapshot = dict(task.ir_snapshot or {})
         dsl_payload = snapshot.get("dify_dsl")
@@ -211,10 +216,9 @@ class ConversionService:
         source_workflow_name: str,
     ) -> dict[str, Any]:
         dify_dsl, report = self.engine.convert_from_ir(ir_workflow)
-        yaml_output = self.engine.dify_generator.to_yaml(dify_dsl)
         snapshot = {
             "ir_workflow": ir_workflow.model_dump(mode="json"),
-            "dify_dsl": dify_dsl.model_dump(mode="json"),
+            "dify_dsl": dify_dsl.model_dump(mode="json") if dify_dsl else None,
             "write_result": None,
             "audit": {
                 "source": {
@@ -225,14 +229,16 @@ class ConversionService:
                 "last_write": None,
             },
         }
+        yaml_output = self.engine.dify_generator.to_yaml(dify_dsl) if dify_dsl else None
         task = MigrationTask(
             source_type=source_type,
             source_workflow_id=source_workflow_id,
             source_workflow_name=source_workflow_name,
-            status="converted",
+            status="converted" if report.supported else "blocked",
             ir_snapshot=snapshot,
             dify_dsl=yaml_output,
             report=report.model_dump(mode="json"),
+            error_message=report.blocking_issues[0] if report.blocking_issues else None,
             completed_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
         db.add(task)
@@ -380,6 +386,7 @@ class ConversionService:
         errors = report.get("errors")
         return {
             "workflow_name": report.get("workflow_name") or "",
+            "supported": bool(report.get("supported", False)),
             "total_nodes": int(report.get("total_nodes") or 0),
             "mapped_count": int(report.get("mapped_count") or 0),
             "partial_count": int(report.get("partial_count") or 0),

--- a/backend/core/engine/converter.py
+++ b/backend/core/engine/converter.py
@@ -4,7 +4,9 @@ from core.coze.parser import CozeParser
 from core.dify.generator import DifyGenerator
 from core.dify.models import DifyDSL
 from core.ir.models import ConversionReport, IRNode, IRWorkflow, NodeConversionResult
+from core.ir.types import IRNodeType
 from core.mapper.node_mapper import NodeMapper
+from core.validation.support_policy import StrictSupportSubsetPolicy
 
 
 class ConversionEngine:
@@ -14,38 +16,45 @@ class ConversionEngine:
         self.coze_parser = CozeParser()
         self.dify_generator = DifyGenerator()
         self.node_mapper = NodeMapper()
+        self.support_policy = StrictSupportSubsetPolicy()
 
-    def convert_from_json(self, content: str | bytes, fmt: str = "json") -> tuple[DifyDSL, ConversionReport]:
+    def convert_from_json(self, content: str | bytes, fmt: str = "json") -> tuple[DifyDSL | None, ConversionReport]:
         ir_workflow = self.coze_parser.parse_file(content, fmt)
         return self.convert_from_ir(ir_workflow)
 
-    def convert_from_dict(self, data: dict) -> tuple[DifyDSL, ConversionReport]:
+    def convert_from_dict(self, data: dict) -> tuple[DifyDSL | None, ConversionReport]:
         ir_workflow = self.coze_parser.parse_dict(data)
         return self.convert_from_ir(ir_workflow)
 
-    def convert_from_ir(self, ir_workflow: IRWorkflow) -> tuple[DifyDSL, ConversionReport]:
+    def convert_from_ir(self, ir_workflow: IRWorkflow) -> tuple[DifyDSL | None, ConversionReport]:
         report = self._build_report(ir_workflow)
-        dify_dsl = self.dify_generator.generate(ir_workflow)
+        dify_dsl = self.dify_generator.generate(ir_workflow) if report.supported else None
         return dify_dsl, report
 
     def _build_report(self, ir_workflow: IRWorkflow) -> ConversionReport:
         results: list[NodeConversionResult] = []
         mapped = partial = unmappable = skipped = 0
+        rules = {node_type: self.node_mapper.get_rule(node_type) for node_type in IRNodeType}
+        support_decision = self.support_policy.assess_workflow(ir_workflow, rules=rules)
 
         all_nodes = self._iter_nodes(ir_workflow.nodes)
         for node in all_nodes:
-            rule = self.node_mapper.get_rule(node.node_type)
+            rule = rules[node.node_type]
+            node_support = support_decision.node_decisions[node.id]
             result = NodeConversionResult(
                 source_node_id=node.id,
                 source_node_type=node.source_type_name,
                 target_node_id=node.id,
                 target_node_type=rule.dify_type,
-                status=rule.status,
-                warnings=[rule.notes] if rule.notes else [],
+                status=node_support.status,
+                support_state=node_support.support_state,
+                support_reasons=node_support.support_reasons,
+                warnings=node_support.warnings,
+                errors=node_support.errors,
             )
             results.append(result)
 
-            match rule.status:
+            match result.status:
                 case "mapped":
                     mapped += 1
                 case "partial":
@@ -56,6 +65,8 @@ class ConversionEngine:
                     skipped += 1
 
         return ConversionReport(
+            supported=support_decision.supported,
+            blocking_issues=support_decision.blocking_issues,
             workflow_name=ir_workflow.name,
             total_nodes=len(all_nodes),
             mapped_count=mapped,
@@ -63,6 +74,7 @@ class ConversionEngine:
             unmappable_count=unmappable,
             skipped_count=skipped,
             node_results=results,
+            errors=support_decision.blocking_issues,
         )
 
     def _iter_nodes(self, nodes: list[IRNode]) -> list[IRNode]:

--- a/backend/core/ir/models.py
+++ b/backend/core/ir/models.py
@@ -90,11 +90,16 @@ class NodeConversionResult(BaseModel):
     target_node_id: str | None = None
     target_node_type: str | None = None
     status: MappingStatus
+    support_state: Literal["supported", "blocked"] = "supported"
+    support_reasons: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
 
 
 class ConversionReport(BaseModel):
+    support_mode: Literal["strict_supported_subset"] = "strict_supported_subset"
+    supported: bool = True
+    blocking_issues: list[str] = Field(default_factory=list)
     workflow_name: str = ""
     total_nodes: int = 0
     mapped_count: int = 0

--- a/backend/core/sync/sync_engine.py
+++ b/backend/core/sync/sync_engine.py
@@ -141,6 +141,23 @@ class SyncEngine:
                     )
                     conversion_id = str(conversion["conversion_id"])
                     self._attach_sync_config(db, conversion_id, config.id)
+                    if not bool((conversion.get("report") or {}).get("supported", True)):
+                        summary["unsupported"] += 1
+                        items.append(
+                            self._result_item(
+                                action="inspect",
+                                status="unsupported",
+                                source_workflow_id=source_id,
+                                source_workflow_name=source_name,
+                                target_app_id=mapping["app_id"] if mapping else None,
+                                conversion_id=conversion_id,
+                                message=(
+                                    (conversion.get("report") or {}).get("blocking_issues")
+                                    or ["Blocked by the strict supported subset."]
+                                )[0],
+                            )
+                        )
+                        continue
 
                     target_app_id = mapping["app_id"] if mapping else None
                     if action == "update":
@@ -317,6 +334,22 @@ class SyncEngine:
                     )
                 )
                 summary["failed"] += 1
+                continue
+            if not bool((converted.get("report") or {}).get("supported", True)):
+                summary["unsupported"] += 1
+                items.append(
+                    self._result_item(
+                        action="inspect",
+                        status="unsupported",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=mapping["app_id"] if mapping else None,
+                        message=(
+                            (converted.get("report") or {}).get("blocking_issues")
+                            or ["Blocked by the strict supported subset."]
+                        )[0],
+                    )
+                )
                 continue
 
             source_snapshots[source_id] = self._normalized_dsl_payload(converted["dsl"])
@@ -755,12 +788,13 @@ class SyncEngine:
 
         canvas = self.conversion_service._extract_canvas(payload)
         ir_workflow = self.conversion_service.engine.coze_parser.parse_dict(canvas)
-        dify_dsl, _report = self.conversion_service.engine.convert_from_ir(ir_workflow)
+        dify_dsl, report = self.conversion_service.engine.convert_from_ir(ir_workflow)
         source_workflow_name = ""
         if isinstance(payload, dict):
             source_workflow_name = str(payload.get("name") or "")
         return {
-            "dsl": dify_dsl.model_dump(mode="json"),
+            "dsl": dify_dsl.model_dump(mode="json") if dify_dsl else {},
+            "report": report.model_dump(mode="json"),
             "source_workflow_name": source_workflow_name or ir_workflow.name or workflow_id,
         }
 

--- a/backend/core/validation/support_policy.py
+++ b/backend/core/validation/support_policy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from core.ir.models import IRNode, IRWorkflow
+from core.ir.types import IRNodeType, MappingStatus
+from core.mapper.mapping_rules import MappingRule
+
+_SUPPORTED_NODE_TYPES = {
+    IRNodeType.START,
+    IRNodeType.END,
+    IRNodeType.OUTPUT_EMITTER,
+}
+
+
+@dataclass(slots=True)
+class NodeSupportDecision:
+    status: MappingStatus
+    support_state: str
+    support_reasons: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class WorkflowSupportDecision:
+    supported: bool
+    blocking_issues: list[str] = field(default_factory=list)
+    node_decisions: dict[str, NodeSupportDecision] = field(default_factory=dict)
+
+
+class StrictSupportSubsetPolicy:
+    """Enforces a deliberately small, high-confidence migration subset."""
+
+    def assess_workflow(self, workflow: IRWorkflow, *, rules: dict[IRNodeType, MappingRule]) -> WorkflowSupportDecision:
+        node_decisions: dict[str, NodeSupportDecision] = {}
+        blocking_issues: list[str] = []
+
+        for node in self._iter_nodes(workflow.nodes):
+            decision = self.assess_node(node, rule=rules[node.node_type])
+            node_decisions[node.id] = decision
+            blocking_issues.extend(decision.errors)
+
+        return WorkflowSupportDecision(
+            supported=not blocking_issues,
+            blocking_issues=self._dedupe(blocking_issues),
+            node_decisions=node_decisions,
+        )
+
+    def assess_node(self, node: IRNode, *, rule: MappingRule) -> NodeSupportDecision:
+        if node.node_type == IRNodeType.COMMENT:
+            return NodeSupportDecision(
+                status=rule.status,
+                support_state="supported",
+            )
+
+        if node.node_type in _SUPPORTED_NODE_TYPES:
+            return NodeSupportDecision(
+                status=rule.status,
+                support_state="supported",
+            )
+
+        reason = self._unsupported_reason(node, rule)
+        return NodeSupportDecision(
+            status=rule.status if rule.status != MappingStatus.SKIPPED else MappingStatus.UNMAPPABLE,
+            support_state="blocked",
+            support_reasons=[reason],
+            errors=[reason],
+        )
+
+    @staticmethod
+    def _unsupported_reason(node: IRNode, rule: MappingRule) -> str:
+        node_label = node.source_type_name or node.node_type.value
+        if rule.status in {MappingStatus.PARTIAL, MappingStatus.UNMAPPABLE}:
+            note = f" {rule.notes}." if rule.notes else ""
+            return f"{node_label} is blocked by the strict supported subset because its mapping is {rule.status}.{note}"
+        return f"{node_label} is not admitted to the strict supported subset yet; semantic coverage is missing."
+
+    @staticmethod
+    def _iter_nodes(nodes: list[IRNode]) -> list[IRNode]:
+        flattened: list[IRNode] = []
+        for node in nodes:
+            flattened.append(node)
+            if node.children:
+                flattened.extend(StrictSupportSubsetPolicy._iter_nodes(node.children))
+        return flattened
+
+    @staticmethod
+    def _dedupe(items: list[str]) -> list[str]:
+        return list(dict.fromkeys(item for item in items if item))

--- a/backend/tests/test_conversion_service.py
+++ b/backend/tests/test_conversion_service.py
@@ -124,11 +124,14 @@ def test_get_conversion_includes_nested_source_graph_summary(tmp_path, monkeypat
 
     source_nodes = {node["id"]: node for node in persisted["source_graph"]["nodes"]}
 
+    assert result["status"] == "blocked"
+    assert result["report"]["supported"] is False
     assert persisted["source_graph"]["node_count"] == 4
     assert persisted["source_graph"]["edge_count"] == 3
     assert source_nodes["loop"]["parent_id"] is None
     assert source_nodes["child-code"]["parent_id"] == "loop"
-    assert persisted["target_graph"]["node_count"] >= 3
+    assert persisted["dsl"] == {}
+    assert persisted["target_graph"] is None
 
 
 def test_list_conversions_returns_paginated_history_without_sync_tasks(tmp_path) -> None:

--- a/backend/tests/test_strict_supported_subset_policy.py
+++ b/backend/tests/test_strict_supported_subset_policy.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.engine.conversion_service import ConversionService
+from db.database import Base
+
+
+_SUPPORTED_CANVAS = {
+    "nodes": [
+        {
+            "id": "start",
+            "type": "1",
+            "meta": {"position": {"x": 0, "y": 0}},
+            "data": {"outputs": [{"type": "string", "name": "input", "required": True}]},
+        },
+        {
+            "id": "answer",
+            "type": "13",
+            "meta": {"position": {"x": 320, "y": 0}},
+            "data": {
+                "inputs": {
+                    "inputParameters": [
+                        {
+                            "name": "answer",
+                            "input": {
+                                "type": "string",
+                                "value": {
+                                    "type": "ref",
+                                    "content": {
+                                        "blockID": "start",
+                                        "name": "input",
+                                        "path": [],
+                                        "source": "block-output",
+                                    },
+                                },
+                            },
+                        }
+                    ]
+                }
+            },
+        },
+    ],
+    "edges": [{"sourceNodeID": "start", "targetNodeID": "answer"}],
+    "versions": {},
+}
+
+_BLOCKED_CANVAS = {
+    "nodes": [
+        {
+            "id": "start",
+            "type": "1",
+            "meta": {"position": {"x": 0, "y": 0}},
+            "data": {"outputs": [{"type": "string", "name": "input", "required": True}]},
+        },
+        {
+            "id": "llm",
+            "type": "3",
+            "meta": {"position": {"x": 320, "y": 0}},
+            "data": {"inputs": {}},
+        },
+    ],
+    "edges": [{"sourceNodeID": "start", "targetNodeID": "llm"}],
+    "versions": {},
+}
+
+
+def test_strict_subset_allows_supported_workflow() -> None:
+    service = ConversionService()
+
+    dsl, report = service.engine.convert_from_dict(_SUPPORTED_CANVAS)
+
+    assert report.supported is True
+    assert report.blocking_issues == []
+    assert dsl is not None
+    assert dsl.workflow.graph.nodes
+
+
+def test_strict_subset_blocks_partial_or_unmappable_workflow() -> None:
+    service = ConversionService()
+
+    dsl, report = service.engine.convert_from_dict(_BLOCKED_CANVAS)
+
+    assert report.supported is False
+    assert dsl is None
+    assert report.blocking_issues
+    assert report.node_results[1].support_state == "blocked"
+
+
+def test_blocked_workflow_is_persisted_without_dsl_artifact(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-blocked.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    service = ConversionService()
+
+    with session_factory() as db:
+        conversion = service.convert_uploaded_file(
+            db,
+            json.dumps(_BLOCKED_CANVAS).encode(),
+            "blocked.json",
+        )
+        persisted = service.get_conversion(db, conversion["conversion_id"])
+
+        with pytest.raises(LookupError, match="has no DSL artifact"):
+            service.get_yaml(db, conversion["conversion_id"])
+
+        with pytest.raises(ValueError, match="strict supported subset"):
+            service.write_to_dify(
+                db,
+                conversion["conversion_id"],
+                db_url="postgresql://writer:supersecret@dify.example:5432/dify",
+            )
+
+    assert conversion["status"] == "blocked"
+    assert conversion["report"]["supported"] is False
+    assert persisted["dsl"] == {}
+    assert persisted["target_graph"] is None
+    assert persisted["error_message"] == conversion["report"]["blocking_issues"][0]

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -127,6 +127,17 @@ class DeletePreviewDifyReader:
         return {"app_id": app_id, "graph": {"nodes": [], "edges": []}, "features": {}}
 
 
+class EmptyDifyReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_apps(self) -> list[dict[str, str]]:
+        return []
+
+    def read_workflow(self, app_id: str) -> dict[str, object] | None:
+        return None
+
+
 class FakeConversionService:
     def __init__(self) -> None:
         self.write_calls: list[tuple[str, str | None, str | None]] = []
@@ -145,7 +156,7 @@ class FakeConversionService:
             status="converted",
             ir_snapshot={"dify_dsl": dsl_payload, "write_result": None},
             dify_dsl="workflow: {}\n",
-            report={"workflow_name": workflow_id, "total_nodes": 1},
+            report={"workflow_name": workflow_id, "total_nodes": 1, "supported": True, "blocking_issues": []},
             completed_at=_utcnow(),
         )
         db.add(task)
@@ -190,6 +201,36 @@ class FakeConversionService:
         }
 
 
+class BlockedConversionService(FakeConversionService):
+    def convert_from_db(self, db, *, db_url: str, workflow_id: str) -> dict[str, object]:
+        blocking_issue = "LLM is blocked by the strict supported subset because its mapping is partial."
+        task = MigrationTask(
+            source_type="database",
+            source_workflow_id=workflow_id,
+            source_workflow_name=f"Workflow {workflow_id}",
+            status="blocked",
+            ir_snapshot={"dify_dsl": None, "write_result": None},
+            dify_dsl=None,
+            report={
+                "workflow_name": workflow_id,
+                "total_nodes": 2,
+                "supported": False,
+                "blocking_issues": [blocking_issue],
+            },
+            error_message=blocking_issue,
+            completed_at=_utcnow(),
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return {
+            "conversion_id": str(task.id),
+            "dsl": {},
+            "report": task.report,
+            "status": task.status,
+        }
+
+
 def _minimal_canvas(node_id: str) -> dict[str, object]:
     start_id = f"{node_id}-start"
     end_id = f"{node_id}-end"
@@ -213,11 +254,49 @@ def _minimal_canvas(node_id: str) -> dict[str, object]:
     }
 
 
+def _blocked_canvas(node_id: str) -> dict[str, object]:
+    start_id = f"{node_id}-start"
+    llm_id = f"{node_id}-llm"
+    return {
+        "nodes": [
+            {
+                "id": start_id,
+                "type": "1",
+                "meta": {"position": {"x": 0, "y": 0}},
+                "data": {"outputs": [{"type": "string", "name": "input", "required": True}]},
+            },
+            {
+                "id": llm_id,
+                "type": "3",
+                "meta": {"position": {"x": 320, "y": 0}},
+                "data": {"inputs": {}},
+            },
+        ],
+        "edges": [{"sourceNodeID": start_id, "targetNodeID": llm_id}],
+        "versions": {},
+    }
+
+
 def _dsl_payload_for(canvas: dict[str, object]) -> dict[str, object]:
     service = ConversionService()
     ir_workflow = service.engine.coze_parser.parse_dict(canvas)
     dsl, _report = service.engine.convert_from_ir(ir_workflow)
     return dsl.model_dump(mode="json")
+
+
+class BlockedPreviewCozeReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_workflows(self) -> list[dict[str, str]]:
+        return [{"id": "wf-blocked", "name": "Blocked Flow"}]
+
+    def read_workflow(self, workflow_id: str) -> dict[str, object] | None:
+        return {
+            "id": workflow_id,
+            "name": "Blocked Flow",
+            "canvas": _blocked_canvas(workflow_id),
+        }
 
 
 def test_execute_sync_persists_create_and_update_results(tmp_path) -> None:
@@ -427,6 +506,94 @@ def test_preview_diff_records_delete_intent_under_selected_policy(tmp_path) -> N
     assert result["items"][0]["status"] == "unsupported"
     assert result["items"][0]["delete_policy"]["mode"] == "approval_required"
     assert result["items"][0]["delete_policy"]["intent_status"] == "approval_pending"
+
+
+def test_preview_diff_marks_blocked_conversions_as_unsupported(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-blocked-preview.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    sync_engine = SyncEngine(
+        ConversionService(),
+        coze_reader_factory=BlockedPreviewCozeReader,
+        dify_reader_factory=EmptyDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Blocked Preview",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        result = sync_engine.preview_diff(db, config)
+        persisted_tasks = db.execute(select(MigrationTask)).scalars().all()
+
+    assert result["status"] == "partial"
+    assert result["summary"] == {
+        "created": 0,
+        "updated": 0,
+        "failed": 0,
+        "skipped": 0,
+        "unsupported": 1,
+        "conflicts": 0,
+    }
+    assert len(result["items"]) == 1
+    assert result["items"][0]["status"] == "unsupported"
+    assert "strict supported subset" in result["items"][0]["message"]
+    assert persisted_tasks == []
+
+
+def test_execute_sync_skips_write_for_blocked_conversions(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-blocked-execute.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    conversion_service = BlockedConversionService()
+    sync_engine = SyncEngine(
+        conversion_service,
+        coze_reader_factory=BlockedPreviewCozeReader,
+        dify_reader_factory=EmptyDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Blocked Execute",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        result = sync_engine.execute_sync(db, config)
+        synced_tasks = (
+            db.execute(select(MigrationTask).where(MigrationTask.sync_config_id == config.id)).scalars().all()
+        )
+
+    assert result["status"] == "partial"
+    assert result["summary"] == {
+        "created": 0,
+        "updated": 0,
+        "failed": 0,
+        "skipped": 0,
+        "unsupported": 1,
+        "conflicts": 0,
+    }
+    assert len(result["items"]) == 1
+    assert result["items"][0]["status"] == "unsupported"
+    assert result["items"][0]["conversion_id"] == "1"
+    assert conversion_service.write_calls == []
+    assert len(synced_tasks) == 1
+    assert synced_tasks[0].status == "blocked"
 
 
 def test_resolve_conflict_source_wins_updates_history_and_persists_resolution(tmp_path) -> None:

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,9 +132,17 @@ Execute conversion pipeline.
 Get conversion result, including the persisted report plus `source_graph` / `target_graph` summaries
 for visual diff views.
 
+The report now includes:
+
+- `support_mode`
+- `supported`
+- `blocking_issues`
+
 ### `GET /convert/{id}/dsl`
 
 Download generated Dify DSL YAML file.
+
+Blocked conversions do not store a DSL artifact, so this endpoint only succeeds when `report.supported = true`.
 
 ### `GET /convert/{id}/report`
 
@@ -146,6 +154,7 @@ Direct-write conversion result to Dify PostgreSQL.
 
 Safety behavior:
 
+- blocked conversions are rejected before any write is attempted
 - raw target DB URLs are not echoed back in API-visible payloads
 - successful and failed writes persist redacted target references plus last-write audit metadata
 - write failures return actionable, sanitized error details

--- a/docs/node-mapping.md
+++ b/docs/node-mapping.md
@@ -1,5 +1,16 @@
 # Node Mapping — Complete 42-Type Reference
 
+> This document describes the full design-time mapping target. Runtime conversion is stricter and currently enforces only the subset documented in [`supported-subset.md`](supported-subset.md).
+
+## Runtime Enforcement
+
+The converter no longer treats every `Partial` or `Mode Change` row below as safe to emit. Under `strict_supported_subset`:
+
+- `Direct` mappings are not automatically admitted unless they are covered by the supported subset policy
+- `Partial`, `Mode Change`, and `Unmappable` rows are blocked at conversion time
+
+See [`supported-subset.md`](supported-subset.md) for the operator-facing contract.
+
 ## Mapping Levels
 
 | Icon | Level | Meaning |

--- a/docs/supported-subset.md
+++ b/docs/supported-subset.md
@@ -1,0 +1,29 @@
+# Strict Supported Subset
+
+This project now enforces a runtime policy called `strict_supported_subset`.
+
+The goal is conservative correctness: only a small verified subset of Coze workflows is allowed to emit Dify DSL. If a workflow falls outside that subset, the converter records a blocked result and stops before DSL generation.
+
+## What Is Currently Admitted
+
+- Entry (`type: 1`) -> `start`
+- Exit (`type: 2`) -> `end`
+- OutputEmitter (`type: 13`) -> `answer`
+- Comment (`type: 31`) -> skipped safely, no Dify node emitted
+
+## What Is Blocked
+
+The strict subset blocks:
+
+- every node whose design-time mapping is `Partial`, `Mode Change`, or `Unmappable`
+- any node type that has not yet been explicitly admitted into the supported subset
+- any workflow containing such nodes, even if other nodes in the same workflow are supported
+
+Blocked conversions:
+
+- return `report.supported = false`
+- persist `status = "blocked"`
+- store no Dify DSL artifact
+- disable direct write to Dify
+
+This policy is intentionally conservative. The subset should only expand when dedicated coverage is added for the new path.

--- a/frontend/src/components/history/ConversionHistoryTable.tsx
+++ b/frontend/src/components/history/ConversionHistoryTable.tsx
@@ -24,7 +24,7 @@ function getStatusTone(status: string): "mapped" | "partial" | "unmappable" | "s
   if (status === "converted" || status === "written" || status === "updated") {
     return "mapped";
   }
-  if (status === "failed" || status === "error" || status === "write_failed") {
+  if (status === "failed" || status === "error" || status === "write_failed" || status === "blocked") {
     return "unmappable";
   }
   if (status === "skipped") {
@@ -130,6 +130,14 @@ export default function ConversionHistoryTable({ items }: { items: ConversionHis
                         }}
                       >
                         {report.errors_count} errors · {report.warnings_count} warnings
+                      </span>
+                      <span
+                        style={{
+                          fontSize: "0.74rem",
+                          color: !report.supported ? "var(--c-red)" : "var(--c-text-tertiary)",
+                        }}
+                      >
+                        {report.supported ? "Inside strict subset" : "Strict subset blocked"}
                       </span>
                     </div>
                   ) : (

--- a/frontend/src/components/result/DirectWriteButton.tsx
+++ b/frontend/src/components/result/DirectWriteButton.tsx
@@ -1,15 +1,27 @@
 import { useState } from "react";
 import { writeToDify } from "../../api/conversion";
 import { usePlatformStore } from "../../store/platformStore";
-import type { WriteResult } from "../../types/ir";
+import type { ConversionReport, WriteResult } from "../../types/ir";
 
-export default function DirectWriteButton({ conversionId }: { conversionId: string }) {
+export default function DirectWriteButton({
+  conversionId,
+  report,
+}: {
+  conversionId: string;
+  report: ConversionReport;
+}) {
   const { difyDbUrl, difyApiBase, difySelectedAppId } = usePlatformStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [result, setResult] = useState<WriteResult | null>(null);
+  const blockedReason =
+    report.blocking_issues[0] || "This workflow is outside the strict supported subset.";
 
   const handleWrite = async () => {
+    if (!report.supported) {
+      setError(blockedReason);
+      return;
+    }
     setLoading(true);
     setError("");
     try {
@@ -30,9 +42,12 @@ export default function DirectWriteButton({ conversionId }: { conversionId: stri
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 6 }}>
-      <button className="btn btn-secondary" onClick={handleWrite} disabled={loading}>
+      <button className="btn btn-secondary" onClick={handleWrite} disabled={loading || !report.supported}>
         {loading ? "Writing..." : difySelectedAppId ? "🗄 Update Dify App" : "🗄 Write to Dify DB"}
       </button>
+      {!error && !report.supported && (
+        <span style={{ fontSize: "0.72rem", color: "var(--c-red)" }}>{blockedReason}</span>
+      )}
       {result && (
         <div style={{ display: "grid", gap: 2 }}>
           <span style={{ fontSize: "0.72rem", color: result.status === "failed" ? "var(--c-red)" : "var(--c-green)" }}>

--- a/frontend/src/components/result/DownloadButton.tsx
+++ b/frontend/src/components/result/DownloadButton.tsx
@@ -1,11 +1,22 @@
 import { useState } from "react";
 import { downloadDSL } from "../../api/conversion";
 
-export default function DownloadButton({ conversionId }: { conversionId: string }) {
+export default function DownloadButton({
+  conversionId,
+  disabled = false,
+  disabledReason = "",
+}: {
+  conversionId: string;
+  disabled?: boolean;
+  disabledReason?: string;
+}) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const handleDownload = async () => {
+    if (disabled) {
+      return;
+    }
     setLoading(true);
     setError("");
     try {
@@ -25,9 +36,12 @@ export default function DownloadButton({ conversionId }: { conversionId: string 
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 6 }}>
-      <button className="btn btn-primary" onClick={handleDownload} disabled={loading}>
+      <button className="btn btn-primary" onClick={handleDownload} disabled={loading || disabled}>
         {loading ? "Downloading..." : "↓ Download DSL"}
       </button>
+      {!error && disabledReason && (
+        <span style={{ fontSize: "0.72rem", color: "var(--c-red)" }}>{disabledReason}</span>
+      )}
       {error && (
         <span style={{ fontSize: "0.72rem", color: "var(--c-red)" }}>{error}</span>
       )}

--- a/frontend/src/components/result/WarningList.tsx
+++ b/frontend/src/components/result/WarningList.tsx
@@ -1,7 +1,9 @@
 import type { NodeConversionResult } from "../../types/ir";
 
 export default function WarningList({ results }: { results: NodeConversionResult[] }) {
-  const warnings = results.filter((r) => r.warnings.length > 0 || r.status === "unmappable");
+  const warnings = results.filter(
+    (r) => r.support_state !== "supported" || r.warnings.length > 0 || r.errors.length > 0,
+  );
   if (warnings.length === 0) return null;
 
   return (
@@ -27,13 +29,16 @@ export default function WarningList({ results }: { results: NodeConversionResult
             <span style={{ opacity: 0.6, marginLeft: 6, fontFamily: "var(--font-mono)", fontSize: "0.7rem" }}>
               {r.source_node_id}
             </span>
-            {r.status === "unmappable" && (
-              <span style={{ color: "var(--c-red)", marginLeft: 8 }}>
-                — No Dify equivalent
-              </span>
+            {r.support_state === "blocked" && (
+              <span style={{ color: "var(--c-red)", marginLeft: 8 }}>— Blocked</span>
             )}
-            {r.warnings.map((w, i) => (
-              <span key={i} style={{ marginLeft: 8 }}>— {w}</span>
+            {[...new Set([...r.support_reasons, ...r.warnings, ...r.errors])].map((message, i) => (
+              <span
+                key={`${r.source_node_id}-${i}`}
+                style={{ marginLeft: 8, color: r.support_state === "blocked" ? "var(--c-red)" : undefined }}
+              >
+                — {message || (r.status === "unmappable" ? "No Dify equivalent" : "Review required")}
+              </span>
             ))}
           </div>
         ))}

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -89,6 +89,12 @@ export default function ResultPage() {
     );
   }
 
+  const blockedReason =
+    activeReport.blocking_issues[0] || "This workflow is outside the strict supported subset.";
+  const exportDescription = !activeReport.supported
+    ? "Blocked workflows do not emit Dify DSL. Resolve the listed nodes before exporting."
+    : t("result.exportOptionsDesc");
+
   return (
     <PageShell
       breadcrumb={breadcrumb}
@@ -96,6 +102,16 @@ export default function ResultPage() {
       subtitle={`${activeReport.workflow_name} — ${t("result.subtitle")}`}
     >
       <ConversionReportView report={activeReport} />
+
+      {!activeReport.supported && (
+        <div className="alert alert--error" style={{ marginTop: 24 }}>
+          <strong>Blocked by strict supported subset.</strong>
+          <div style={{ marginTop: 6 }}>{blockedReason}</div>
+          <div style={{ marginTop: 6, fontSize: "0.78rem" }}>
+            No Dify DSL was generated for this conversion, so export actions are disabled.
+          </div>
+        </div>
+      )}
 
       {error && (
         <div className="alert alert--error" style={{ marginTop: 20 }}>
@@ -117,12 +133,16 @@ export default function ResultPage() {
         <div>
           <div className="section-title">{t("result.exportOptions")}</div>
           <p style={{ fontSize: "0.82rem", color: "var(--c-text-tertiary)", marginTop: 4 }}>
-            {t("result.exportOptionsDesc")}
+            {exportDescription}
           </p>
         </div>
         <div style={{ display: "flex", gap: 12 }}>
-          <DownloadButton conversionId={conversionId} />
-          <DirectWriteButton conversionId={conversionId} />
+          <DownloadButton
+            conversionId={conversionId}
+            disabled={!activeReport.supported}
+            disabledReason={!activeReport.supported ? blockedReason : ""}
+          />
+          <DirectWriteButton conversionId={conversionId} report={activeReport} />
         </div>
       </div>
 

--- a/frontend/src/types/ir.ts
+++ b/frontend/src/types/ir.ts
@@ -1,6 +1,7 @@
 import type { DatabaseTargetRef } from "./audit";
 
 export type MappingStatus = "mapped" | "partial" | "unmappable" | "skipped";
+export type SupportState = "supported" | "blocked";
 
 export interface NodeConversionResult {
   source_node_id: string;
@@ -8,11 +9,16 @@ export interface NodeConversionResult {
   target_node_id: string | null;
   target_node_type: string | null;
   status: MappingStatus;
+  support_state: SupportState;
+  support_reasons: string[];
   warnings: string[];
   errors: string[];
 }
 
 export interface ConversionReport {
+  support_mode: "strict_supported_subset";
+  supported: boolean;
+  blocking_issues: string[];
   workflow_name: string;
   total_nodes: number;
   mapped_count: number;
@@ -80,6 +86,7 @@ export interface ConversionAudit {
 
 export interface ConversionHistoryReportSummary {
   workflow_name: string;
+  supported: boolean;
   total_nodes: number;
   mapped_count: number;
   partial_count: number;


### PR DESCRIPTION
## Why
Migration correctness needed a hard runtime boundary. Partial and unmappable Coze nodes were still allowed to emit best-effort Dify DSL, which created false confidence and made downstream write flows unsafe.

## What Changed
- add a strict supported subset policy that blocks unsupported workflows before DSL generation
- persist blocked conversions without DSL artifacts and surface that blocked state in reports, sync, and result views
- add backend regression coverage and docs for the blocked-workflow contract

## Verification
- `./scripts/ci-local.sh`

Closes #41
