### PR TITLE
Add semantic equivalence test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - **Verified path**: file-based Coze workflow conversion into Dify graph / DSL for the strict supported subset.
 - **Verified in local testing**: migrated workflow can be written into a local Dify PostgreSQL instance and opened in Dify.
 - **Strict runtime policy**: partial and unmappable nodes are blocked instead of emitting best-effort DSL.
-- **Coverage baseline**: a 42-case Coze workflow corpus tracks the mapped node classes behind the current support boundary.
+- **Coverage baseline**: a 42-case Coze workflow corpus plus semantic equivalence checks back the current support boundary.
 - **Partially built**: platform browse, dev mode helpers, and direct-write UI.
 - **Not production-ready yet**: incremental sync, migration history persistence, and several API/database import flows.
 

--- a/backend/tests/coze_workflow_corpus.py
+++ b/backend/tests/coze_workflow_corpus.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -9,6 +9,8 @@ class CorpusCase:
     name: str
     canvas: dict[str, Any]
     expected_supported: bool
+    semantic_inputs: dict[str, Any] = field(default_factory=dict)
+    expected_terminal: dict[str, Any] | None = None
 
 
 def _start_node(*, name: str = "input", var_type: str = "string") -> dict[str, Any]:
@@ -109,6 +111,8 @@ def _output_emitter_case(name: str, *, literal: str | None = None) -> CorpusCase
             "versions": {},
         },
         expected_supported=True,
+        semantic_inputs={"input": "hello world"},
+        expected_terminal={"answer": literal or "hello world"},
     )
 
 
@@ -179,6 +183,8 @@ def _baseline_case() -> CorpusCase:
             "versions": {},
         },
         expected_supported=True,
+        semantic_inputs={"input": "hello world"},
+        expected_terminal={},
     )
 
 
@@ -200,6 +206,8 @@ def _comment_case() -> CorpusCase:
             "versions": {},
         },
         expected_supported=True,
+        semantic_inputs={"input": "hello world"},
+        expected_terminal={},
     )
 
 

--- a/backend/tests/semantic_harness.py
+++ b/backend/tests/semantic_harness.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from typing import Any
+
+from core.dify.models import DifyDSL
+from core.ir.models import IRVariable, IRWorkflow
+from core.ir.types import IRNodeType
+
+_TEMPLATE_RE = re.compile(r"\{\{#([^#]+)#\}\}")
+
+
+def execute_ir_workflow(workflow: IRWorkflow, inputs: dict[str, Any]) -> dict[str, Any]:
+    node_map = {node.id: node for node in workflow.nodes}
+    order = _topological_order(node_map, [(edge.source_node_id, edge.target_node_id) for edge in workflow.edges])
+    values: dict[str, dict[str, Any]] = {}
+    terminal: dict[str, Any] = {}
+
+    for node_id in order:
+        node = node_map[node_id]
+        if node.node_type == IRNodeType.START:
+            values[node.id] = dict(inputs)
+        elif node.node_type == IRNodeType.OUTPUT_EMITTER:
+            values[node.id] = {"answer": _build_ir_answer(node.inputs, values)}
+            terminal = values[node.id]
+        elif node.node_type == IRNodeType.END:
+            values[node.id] = {var.name: _resolve_ir_variable(values, var) for var in node.inputs}
+            terminal = values[node.id]
+        else:
+            values[node.id] = {}
+
+    return terminal
+
+
+def execute_dify_workflow(dsl: DifyDSL, inputs: dict[str, Any]) -> dict[str, Any]:
+    node_map = {node.id: node for node in dsl.workflow.graph.nodes}
+    order = _topological_order(node_map, [(edge.source, edge.target) for edge in dsl.workflow.graph.edges])
+    values: dict[str, dict[str, Any]] = {}
+    terminal: dict[str, Any] = {}
+
+    for node_id in order:
+        node = node_map[node_id]
+        node_type = node.data.type
+        if node_type == "start":
+            values[node.id] = dict(inputs)
+        elif node_type == "answer":
+            values[node.id] = {"answer": _render_template(node.data.answer, values)}
+            terminal = values[node.id]
+        elif node_type == "end":
+            values[node.id] = {
+                entry["variable"]: _resolve_selector(values, entry.get("value_selector", []))
+                for entry in node.data.outputs
+            }
+            terminal = values[node.id]
+        else:
+            values[node.id] = {}
+
+    return terminal
+
+
+def _topological_order(node_map: dict[str, Any], edges: list[tuple[str, str]]) -> list[str]:
+    indegree = {node_id: 0 for node_id in node_map}
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    for source, target in edges:
+        if source not in node_map or target not in node_map:
+            continue
+        outgoing[source].append(target)
+        indegree[target] += 1
+
+    queue = deque(node_id for node_id, degree in indegree.items() if degree == 0)
+    order: list[str] = []
+    while queue:
+        current = queue.popleft()
+        order.append(current)
+        for target in outgoing[current]:
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                queue.append(target)
+
+    return order if len(order) == len(node_map) else list(node_map)
+
+
+def _resolve_ir_variable(values: dict[str, dict[str, Any]], var: IRVariable) -> Any:
+    if var.literal_value is not None:
+        return var.literal_value
+    if var.ref is None:
+        return None
+    return values.get(var.ref.source_node_id, {}).get(var.ref.field_name)
+
+
+def _resolve_selector(values: dict[str, dict[str, Any]], selector: list[str]) -> Any:
+    if len(selector) < 2:
+        return None
+    current: Any = values.get(selector[0], {}).get(selector[1])
+    for part in selector[2:]:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def _build_ir_answer(variables: list[IRVariable], values: dict[str, dict[str, Any]]) -> str:
+    fragments: list[str] = []
+    for var in variables:
+        if var.literal_value is not None:
+            fragments.append(str(var.literal_value))
+        elif var.ref is not None:
+            resolved = values.get(var.ref.source_node_id, {}).get(var.ref.field_name)
+            if resolved is not None:
+                fragments.append(str(resolved))
+    return "\n".join(fragment for fragment in fragments if fragment)
+
+
+def _render_template(template: str, values: dict[str, dict[str, Any]]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        parts = match.group(1).split(".")
+        return str(_resolve_selector(values, parts) or "")
+
+    return _TEMPLATE_RE.sub(replace, template)

--- a/backend/tests/test_semantic_equivalence.py
+++ b/backend/tests/test_semantic_equivalence.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from core.engine.conversion_service import ConversionService
+
+from .coze_workflow_corpus import CORPUS_CASES
+from .semantic_harness import execute_dify_workflow, execute_ir_workflow
+
+
+SEMANTIC_CASES = [case for case in CORPUS_CASES if case.expected_terminal is not None]
+
+
+def test_semantic_corpus_cases_exist() -> None:
+    assert [case.name for case in SEMANTIC_CASES] == [
+        "baseline_start_end",
+        "output_emitter_passthrough",
+        "output_emitter_literal_supported_duplicate",
+        "comment_annotation",
+    ]
+
+
+@pytest.mark.parametrize("case", SEMANTIC_CASES, ids=lambda case: case.name)
+def test_supported_cases_match_ir_and_dify_terminal_semantics(case) -> None:
+    service = ConversionService()
+    ir_workflow = service.engine.coze_parser.parse_dict(case.canvas)
+
+    dsl, report = service.engine.convert_from_ir(ir_workflow)
+
+    assert report.supported is True
+    assert dsl is not None
+    assert execute_ir_workflow(ir_workflow, case.semantic_inputs) == case.expected_terminal
+    assert execute_dify_workflow(dsl, case.semantic_inputs) == case.expected_terminal


### PR DESCRIPTION
## Why
DSL structure checks alone are not enough for migration correctness. The admitted subset also needs semantic checks that compare the IR execution result with the generated Dify workflow result on the same inputs.

## What Changed
- extend the corpus metadata with semantic fixtures for the currently admitted subset
- add a lightweight semantic harness that executes IR workflows and generated Dify workflows to compare terminal outputs
- add parameterized semantic equivalence tests for the supported strict-subset cases

## Verification
- `./scripts/ci-local.sh`

Closes #43
