### PR TITLE
Add golden snapshot coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - **Verified path**: file-based Coze workflow conversion into Dify graph / DSL for the strict supported subset.
 - **Verified in local testing**: migrated workflow can be written into a local Dify PostgreSQL instance and opened in Dify.
 - **Strict runtime policy**: partial and unmappable nodes are blocked instead of emitting best-effort DSL.
-- **Coverage baseline**: a 42-case Coze workflow corpus plus semantic equivalence checks back the current support boundary.
+- **Coverage baseline**: a 42-case Coze workflow corpus, semantic equivalence checks, and golden snapshots back the current support boundary.
 - **Partially built**: platform browse, dev mode helpers, and direct-write UI.
 - **Not production-ready yet**: incremental sync, migration history persistence, and several API/database import flows.
 

--- a/backend/tests/coze_workflow_corpus.py
+++ b/backend/tests/coze_workflow_corpus.py
@@ -11,6 +11,7 @@ class CorpusCase:
     expected_supported: bool
     semantic_inputs: dict[str, Any] = field(default_factory=dict)
     expected_terminal: dict[str, Any] | None = None
+    golden_snapshot: str | None = None
 
 
 def _start_node(*, name: str = "input", var_type: str = "string") -> dict[str, Any]:
@@ -113,6 +114,7 @@ def _output_emitter_case(name: str, *, literal: str | None = None) -> CorpusCase
         expected_supported=True,
         semantic_inputs={"input": "hello world"},
         expected_terminal={"answer": literal or "hello world"},
+        golden_snapshot=name,
     )
 
 
@@ -185,6 +187,7 @@ def _baseline_case() -> CorpusCase:
         expected_supported=True,
         semantic_inputs={"input": "hello world"},
         expected_terminal={},
+        golden_snapshot="baseline_start_end",
     )
 
 

--- a/backend/tests/golden/strict_supported_subset/baseline_start_end.yml
+++ b/backend/tests/golden/strict_supported_subset/baseline_start_end.yml
@@ -1,0 +1,66 @@
+version: 0.6.0
+kind: app
+app:
+  mode: workflow
+  name: Migrated Workflow
+  description: Migrated from Coze
+  icon: 🤖
+  icon_background: '#FFEAD5'
+dependencies: []
+workflow:
+  graph:
+    nodes:
+    - id: start
+      data:
+        type: start
+        title: Entry
+        desc: ''
+        selected: false
+        variables:
+        - type: text-input
+          label: input
+          variable: input
+          required: true
+      position:
+        x: 0.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    - id: end
+      data:
+        type: end
+        title: Exit
+        desc: ''
+        selected: false
+        outputs: []
+      position:
+        x: 640.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    edges:
+    - id: start-source-end-target
+      source: start
+      target: end
+      sourceHandle: source
+      targetHandle: target
+      type: custom
+      data:
+        sourceType: start
+        targetType: end
+        isInIteration: false
+        isInLoop: false
+      zIndex: 0
+    viewport:
+      x: 0
+      y: 0
+      zoom: 0.7
+  features: {}
+  conversation_variables: []
+  environment_variables: []

--- a/backend/tests/golden/strict_supported_subset/output_emitter_literal_supported_duplicate.yml
+++ b/backend/tests/golden/strict_supported_subset/output_emitter_literal_supported_duplicate.yml
@@ -1,0 +1,69 @@
+version: 0.6.0
+kind: app
+app:
+  mode: workflow
+  name: Migrated Workflow
+  description: Migrated from Coze
+  icon: 🤖
+  icon_background: '#FFEAD5'
+dependencies: []
+workflow:
+  graph:
+    nodes:
+    - id: start
+      data:
+        type: start
+        title: Entry
+        desc: ''
+        selected: false
+        variables:
+        - type: text-input
+          label: input
+          variable: input
+          required: true
+      position:
+        x: 0.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    - id: answer
+      data:
+        type: answer
+        title: OutputEmitter
+        desc: ''
+        selected: false
+        variables:
+        - variable: answer
+          value_selector: []
+        answer: fixed literal
+      position:
+        x: 320.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    edges:
+    - id: start-source-answer-target
+      source: start
+      target: answer
+      sourceHandle: source
+      targetHandle: target
+      type: custom
+      data:
+        sourceType: start
+        targetType: answer
+        isInIteration: false
+        isInLoop: false
+      zIndex: 0
+    viewport:
+      x: 0
+      y: 0
+      zoom: 0.7
+  features: {}
+  conversation_variables: []
+  environment_variables: []

--- a/backend/tests/golden/strict_supported_subset/output_emitter_passthrough.yml
+++ b/backend/tests/golden/strict_supported_subset/output_emitter_passthrough.yml
@@ -1,0 +1,71 @@
+version: 0.6.0
+kind: app
+app:
+  mode: workflow
+  name: Migrated Workflow
+  description: Migrated from Coze
+  icon: 🤖
+  icon_background: '#FFEAD5'
+dependencies: []
+workflow:
+  graph:
+    nodes:
+    - id: start
+      data:
+        type: start
+        title: Entry
+        desc: ''
+        selected: false
+        variables:
+        - type: text-input
+          label: input
+          variable: input
+          required: true
+      position:
+        x: 0.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    - id: answer
+      data:
+        type: answer
+        title: OutputEmitter
+        desc: ''
+        selected: false
+        variables:
+        - variable: answer
+          value_selector:
+          - start
+          - input
+        answer: '{{#start.input#}}'
+      position:
+        x: 320.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    edges:
+    - id: start-source-answer-target
+      source: start
+      target: answer
+      sourceHandle: source
+      targetHandle: target
+      type: custom
+      data:
+        sourceType: start
+        targetType: answer
+        isInIteration: false
+        isInLoop: false
+      zIndex: 0
+    viewport:
+      x: 0
+      y: 0
+      zoom: 0.7
+  features: {}
+  conversation_variables: []
+  environment_variables: []

--- a/backend/tests/test_golden_snapshots.py
+++ b/backend/tests/test_golden_snapshots.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.engine.conversion_service import ConversionService
+
+from .coze_workflow_corpus import CORPUS_CASES
+
+_SNAPSHOT_DIR = Path(__file__).with_name("golden").joinpath("strict_supported_subset")
+_GOLDEN_CASES = [case for case in CORPUS_CASES if case.golden_snapshot]
+
+
+def test_golden_snapshot_cases_exist() -> None:
+    assert [case.name for case in _GOLDEN_CASES] == [
+        "baseline_start_end",
+        "output_emitter_passthrough",
+        "output_emitter_literal_supported_duplicate",
+    ]
+
+
+@pytest.mark.parametrize("case", _GOLDEN_CASES, ids=lambda case: case.name)
+def test_supported_cases_match_golden_yaml_snapshots(case) -> None:
+    service = ConversionService()
+
+    dsl, report = service.engine.convert_from_dict(case.canvas)
+
+    assert report.supported is True
+    assert dsl is not None
+    expected_snapshot = yaml.safe_load((_SNAPSHOT_DIR / f"{case.golden_snapshot}.yml").read_text())
+    actual_snapshot = yaml.safe_load(service.engine.dify_generator.to_yaml(dsl))
+    assert actual_snapshot == expected_snapshot


### PR DESCRIPTION
## Why
Even for the admitted subset, generated Dify YAML can drift over time without obvious functional failures. We need committed snapshots so structural changes become explicit review events instead of incidental output churn.

## What Changed
- extend the corpus metadata with golden snapshot references for the currently admitted subset
- add committed YAML snapshots for the supported strict-subset workflows
- add snapshot tests that fail whenever generated Dify YAML changes without an explicit review update

## Verification
- `./scripts/ci-local.sh`

Closes #44
