### PR TITLE
Add manual review gates for Python code migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@
 | 📂 **File Import + DSL Export** | ✅ Verified | Upload local workflow file and export generated DSL |
 | 🗺️ **Node Mapping** | 🟡 Strict Subset | Runtime only emits DSL for the verified supported subset; partial and unmappable nodes are blocked |
 | 🔀 **Variable Transform** | 🟡 Partial | Common `BlockInputReference` cases work; edge cases still exist |
-| 📋 **Conversion Report** | ✅ Verified | Mapping stats plus strict-subset support status and blocking issues |
-| 🗄️ **Direct Dify DB Write** | 🟡 Guarded | Only allowed for conversions inside the strict supported subset |
+| 📋 **Conversion Report** | ✅ Verified | Mapping stats plus strict-subset support status, blocking issues, and manual-review gates |
+| 🗄️ **Direct Dify DB Write** | 🟡 Guarded | Only allowed for supported conversions; high-risk nodes require explicit manual-review confirmation |
 | 📊 **Visual Diff** | 🟡 Basic | Current UI shows report + mapping table, not a full graph diff |
 | 🔍 **Platform Browse** | 🚧 In Progress | Connection UI exists, workflow selection flow is not completed |
 | 🛠️ **Dev Mode** | 🟡 Experimental | Local service detection exists, but one-click workflow operations are limited |
@@ -53,6 +53,7 @@
 - **Verified path**: file-based Coze workflow conversion into Dify graph / DSL for the strict supported subset.
 - **Verified in local testing**: migrated workflow can be written into a local Dify PostgreSQL instance and opened in Dify.
 - **Strict runtime policy**: partial and unmappable nodes are blocked instead of emitting best-effort DSL.
+- **Manual-review gate**: Python `CodeRunner` conversions are allowed only with explicit human confirmation before direct write.
 - **Coverage baseline**: a 42-case Coze workflow corpus, semantic equivalence checks, and golden snapshots back the current support boundary.
 - **Partially built**: platform browse, dev mode helpers, and direct-write UI.
 - **Not production-ready yet**: incremental sync, migration history persistence, and several API/database import flows.
@@ -67,6 +68,8 @@ The current runtime contract is intentionally conservative. Automatic DSL genera
 - Exit (`end`)
 - OutputEmitter (`answer`)
 - Comment (`skipped safely`)
+
+Python `CodeRunner` nodes are admitted only with a hard manual-review gate before `write-to-dify`.
 
 Everything else that is still marked as partial, mode-change, or unmappable in the 42-type mapping table is blocked at conversion time. See [`docs/supported-subset.md`](docs/supported-subset.md).
 
@@ -154,7 +157,7 @@ Some endpoints below exist in the API surface but are not all fully wired in the
 | `POST` | `/api/v1/coze/upload` | Upload Coze workflow file |
 | `POST` | `/api/v1/convert` | Execute conversion |
 | `GET`  | `/api/v1/convert/{id}/dsl` | Download Dify DSL |
-| `POST` | `/api/v1/convert/{id}/write-to-dify` | Write converted DSL directly to Dify PostgreSQL (blocked conversions are rejected) |
+| `POST` | `/api/v1/convert/{id}/write-to-dify` | Write converted DSL directly to Dify PostgreSQL (`confirm_reviewed` required for manual-review cases) |
 
 ### Sync
 

--- a/backend/api/endpoints/conversion.py
+++ b/backend/api/endpoints/conversion.py
@@ -27,6 +27,7 @@ class DbConversionRequest(BaseModel):
 class WriteToDifyRequest(BaseModel):
     db_url: str | None = None
     app_id: str | None = None
+    confirm_reviewed: bool = False
 
 
 @router.get("")
@@ -131,7 +132,13 @@ async def write_to_dify(
     db: Session = Depends(get_db),
 ):
     try:
-        return service.write_to_dify(db, conversion_id, db_url=req.db_url, app_id=req.app_id)
+        return service.write_to_dify(
+            db,
+            conversion_id,
+            db_url=req.db_url,
+            app_id=req.app_id,
+            confirm_reviewed=req.confirm_reviewed,
+        )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:

--- a/backend/core/engine/conversion_service.py
+++ b/backend/core/engine/conversion_service.py
@@ -125,6 +125,7 @@ class ConversionService:
         *,
         db_url: str | None = None,
         app_id: str | None = None,
+        confirm_reviewed: bool = False,
     ) -> dict[str, Any]:
         task = self._get_task(db, conversion_id)
         target_db_url = db_url or settings.dify_database_url
@@ -134,6 +135,10 @@ class ConversionService:
         if not bool(report.get("supported", True)):
             blocking_issues = report.get("blocking_issues") or []
             detail = blocking_issues[0] if blocking_issues else "This workflow is outside the strict supported subset."
+            raise ValueError(detail)
+        if bool(report.get("requires_manual_review")) and not confirm_reviewed:
+            review_reasons = report.get("manual_review_reasons") or []
+            detail = review_reasons[0] if review_reasons else "Manual review is required before write-to-Dify."
             raise ValueError(detail)
 
         snapshot = dict(task.ir_snapshot or {})
@@ -387,6 +392,7 @@ class ConversionService:
         return {
             "workflow_name": report.get("workflow_name") or "",
             "supported": bool(report.get("supported", False)),
+            "requires_manual_review": bool(report.get("requires_manual_review", False)),
             "total_nodes": int(report.get("total_nodes") or 0),
             "mapped_count": int(report.get("mapped_count") or 0),
             "partial_count": int(report.get("partial_count") or 0),

--- a/backend/core/engine/converter.py
+++ b/backend/core/engine/converter.py
@@ -34,6 +34,8 @@ class ConversionEngine:
     def _build_report(self, ir_workflow: IRWorkflow) -> ConversionReport:
         results: list[NodeConversionResult] = []
         mapped = partial = unmappable = skipped = 0
+        warnings: list[str] = []
+        errors: list[str] = []
         rules = {node_type: self.node_mapper.get_rule(node_type) for node_type in IRNodeType}
         support_decision = self.support_policy.assess_workflow(ir_workflow, rules=rules)
 
@@ -53,6 +55,8 @@ class ConversionEngine:
                 errors=node_support.errors,
             )
             results.append(result)
+            warnings.extend(result.warnings)
+            errors.extend(result.errors)
 
             match result.status:
                 case "mapped":
@@ -66,7 +70,9 @@ class ConversionEngine:
 
         return ConversionReport(
             supported=support_decision.supported,
+            requires_manual_review=support_decision.requires_manual_review,
             blocking_issues=support_decision.blocking_issues,
+            manual_review_reasons=support_decision.manual_review_reasons,
             workflow_name=ir_workflow.name,
             total_nodes=len(all_nodes),
             mapped_count=mapped,
@@ -74,7 +80,8 @@ class ConversionEngine:
             unmappable_count=unmappable,
             skipped_count=skipped,
             node_results=results,
-            errors=support_decision.blocking_issues,
+            warnings=self._dedupe(warnings),
+            errors=self._dedupe(errors),
         )
 
     def _iter_nodes(self, nodes: list[IRNode]) -> list[IRNode]:
@@ -84,3 +91,7 @@ class ConversionEngine:
             if node.children:
                 flattened.extend(self._iter_nodes(node.children))
         return flattened
+
+    @staticmethod
+    def _dedupe(items: list[str]) -> list[str]:
+        return list(dict.fromkeys(item for item in items if item))

--- a/backend/core/ir/models.py
+++ b/backend/core/ir/models.py
@@ -90,7 +90,7 @@ class NodeConversionResult(BaseModel):
     target_node_id: str | None = None
     target_node_type: str | None = None
     status: MappingStatus
-    support_state: Literal["supported", "blocked"] = "supported"
+    support_state: Literal["supported", "blocked", "manual_review"] = "supported"
     support_reasons: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
@@ -99,7 +99,9 @@ class NodeConversionResult(BaseModel):
 class ConversionReport(BaseModel):
     support_mode: Literal["strict_supported_subset"] = "strict_supported_subset"
     supported: bool = True
+    requires_manual_review: bool = False
     blocking_issues: list[str] = Field(default_factory=list)
+    manual_review_reasons: list[str] = Field(default_factory=list)
     workflow_name: str = ""
     total_nodes: int = 0
     mapped_count: int = 0

--- a/backend/core/sync/sync_engine.py
+++ b/backend/core/sync/sync_engine.py
@@ -158,6 +158,21 @@ class SyncEngine:
                             )
                         )
                         continue
+                    manual_review_message = self._manual_review_message(conversion.get("report"))
+                    if manual_review_message is not None:
+                        summary["unsupported"] += 1
+                        items.append(
+                            self._result_item(
+                                action="inspect",
+                                status="unsupported",
+                                source_workflow_id=source_id,
+                                source_workflow_name=source_name,
+                                target_app_id=mapping["app_id"] if mapping else None,
+                                conversion_id=conversion_id,
+                                message=manual_review_message,
+                            )
+                        )
+                        continue
 
                     target_app_id = mapping["app_id"] if mapping else None
                     if action == "update":
@@ -348,6 +363,20 @@ class SyncEngine:
                             (converted.get("report") or {}).get("blocking_issues")
                             or ["Blocked by the strict supported subset."]
                         )[0],
+                    )
+                )
+                continue
+            manual_review_message = self._manual_review_message(converted.get("report"))
+            if manual_review_message is not None:
+                summary["unsupported"] += 1
+                items.append(
+                    self._result_item(
+                        action="inspect",
+                        status="unsupported",
+                        source_workflow_id=source_id,
+                        source_workflow_name=source_name,
+                        target_app_id=mapping["app_id"] if mapping else None,
+                        message=manual_review_message,
                     )
                 )
                 continue
@@ -688,6 +717,15 @@ class SyncEngine:
         return "completed"
 
     @staticmethod
+    def _manual_review_message(report: Any) -> str | None:
+        if not isinstance(report, dict) or not bool(report.get("requires_manual_review", False)):
+            return None
+        reasons = report.get("manual_review_reasons")
+        if isinstance(reasons, list) and reasons:
+            return str(reasons[0])
+        return "Manual review is required before write-to-Dify; automated sync blocks this workflow."
+
+    @staticmethod
     def _result_item(
         *,
         action: str,
@@ -774,6 +812,9 @@ class SyncEngine:
         )
         conversion_id = str(conversion["conversion_id"])
         self._attach_sync_config(db, conversion_id, config.id)
+        manual_review_message = self._manual_review_message(conversion.get("report"))
+        if manual_review_message is not None:
+            raise ValueError(manual_review_message)
         return self.conversion_service.write_to_dify(
             db,
             conversion_id,

--- a/backend/core/validation/support_policy.py
+++ b/backend/core/validation/support_policy.py
@@ -12,6 +12,8 @@ _SUPPORTED_NODE_TYPES = {
     IRNodeType.OUTPUT_EMITTER,
 }
 
+_MANUAL_REVIEW_REASON_CODE = "Python code nodes are admitted only with mandatory manual review before write-to-Dify."
+
 
 @dataclass(slots=True)
 class NodeSupportDecision:
@@ -25,7 +27,9 @@ class NodeSupportDecision:
 @dataclass(slots=True)
 class WorkflowSupportDecision:
     supported: bool
+    requires_manual_review: bool = False
     blocking_issues: list[str] = field(default_factory=list)
+    manual_review_reasons: list[str] = field(default_factory=list)
     node_decisions: dict[str, NodeSupportDecision] = field(default_factory=dict)
 
 
@@ -35,15 +39,20 @@ class StrictSupportSubsetPolicy:
     def assess_workflow(self, workflow: IRWorkflow, *, rules: dict[IRNodeType, MappingRule]) -> WorkflowSupportDecision:
         node_decisions: dict[str, NodeSupportDecision] = {}
         blocking_issues: list[str] = []
+        manual_review_reasons: list[str] = []
 
         for node in self._iter_nodes(workflow.nodes):
             decision = self.assess_node(node, rule=rules[node.node_type])
             node_decisions[node.id] = decision
             blocking_issues.extend(decision.errors)
+            if decision.support_state == "manual_review":
+                manual_review_reasons.extend(decision.support_reasons or decision.warnings)
 
         return WorkflowSupportDecision(
             supported=not blocking_issues,
+            requires_manual_review=bool(manual_review_reasons),
             blocking_issues=self._dedupe(blocking_issues),
+            manual_review_reasons=self._dedupe(manual_review_reasons),
             node_decisions=node_decisions,
         )
 
@@ -58,6 +67,14 @@ class StrictSupportSubsetPolicy:
             return NodeSupportDecision(
                 status=rule.status,
                 support_state="supported",
+            )
+
+        if self._is_admitted_python_code(node):
+            return NodeSupportDecision(
+                status=rule.status,
+                support_state="manual_review",
+                support_reasons=[_MANUAL_REVIEW_REASON_CODE],
+                warnings=[_MANUAL_REVIEW_REASON_CODE],
             )
 
         reason = self._unsupported_reason(node, rule)
@@ -84,6 +101,14 @@ class StrictSupportSubsetPolicy:
             if node.children:
                 flattened.extend(StrictSupportSubsetPolicy._iter_nodes(node.children))
         return flattened
+
+    @staticmethod
+    def _is_admitted_python_code(node: IRNode) -> bool:
+        if node.node_type != IRNodeType.CODE:
+            return False
+        language = str(node.config.get("language") or "").strip().lower()
+        code = str(node.config.get("code") or "").strip()
+        return language == "python3" and bool(code)
 
     @staticmethod
     def _dedupe(items: list[str]) -> list[str]:

--- a/backend/tests/coze_workflow_corpus.py
+++ b/backend/tests/coze_workflow_corpus.py
@@ -9,6 +9,7 @@ class CorpusCase:
     name: str
     canvas: dict[str, Any]
     expected_supported: bool
+    expected_manual_review: bool = False
     semantic_inputs: dict[str, Any] = field(default_factory=dict)
     expected_terminal: dict[str, Any] | None = None
     golden_snapshot: str | None = None
@@ -172,7 +173,11 @@ def _python_code_case() -> CorpusCase:
             "edges": [_edge("start", "code"), _edge("code", "answer")],
             "versions": {},
         },
-        expected_supported=False,
+        expected_supported=True,
+        expected_manual_review=True,
+        semantic_inputs={"input": "hello world"},
+        expected_terminal={"answer": "HELLO WORLD"},
+        golden_snapshot="code_python_uppercase",
     )
 
 

--- a/backend/tests/golden/strict_supported_subset/code_python_uppercase.yml
+++ b/backend/tests/golden/strict_supported_subset/code_python_uppercase.yml
@@ -1,0 +1,107 @@
+version: 0.6.0
+kind: app
+app:
+  mode: workflow
+  name: Migrated Workflow
+  description: Migrated from Coze
+  icon: 🤖
+  icon_background: '#FFEAD5'
+dependencies: []
+workflow:
+  graph:
+    nodes:
+    - id: start
+      data:
+        type: start
+        title: Entry
+        desc: ''
+        selected: false
+        variables:
+        - type: text-input
+          label: input
+          variable: input
+          required: true
+      position:
+        x: 0.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    - id: code
+      data:
+        type: code
+        title: CodeRunner
+        desc: ''
+        selected: false
+        code: "def main(value):\n    return {'result': value.upper()}\n"
+        code_language: python3
+        variables:
+        - variable: value
+          value_selector:
+          - start
+          - input
+        outputs:
+          result:
+            type: string
+      position:
+        x: 320.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    - id: answer
+      data:
+        type: answer
+        title: OutputEmitter
+        desc: ''
+        selected: false
+        variables:
+        - variable: answer
+          value_selector:
+          - code
+          - result
+        answer: '{{#code.result#}}'
+      position:
+        x: 640.0
+        y: 0.0
+      width: 244
+      height: 90
+      type: custom
+      sourcePosition: right
+      targetPosition: left
+    edges:
+    - id: start-source-code-target
+      source: start
+      target: code
+      sourceHandle: source
+      targetHandle: target
+      type: custom
+      data:
+        sourceType: start
+        targetType: code
+        isInIteration: false
+        isInLoop: false
+      zIndex: 0
+    - id: code-source-answer-target
+      source: code
+      target: answer
+      sourceHandle: source
+      targetHandle: target
+      type: custom
+      data:
+        sourceType: code
+        targetType: answer
+        isInIteration: false
+        isInLoop: false
+      zIndex: 0
+    viewport:
+      x: 0
+      y: 0
+      zoom: 0.7
+  features: {}
+  conversation_variables: []
+  environment_variables: []

--- a/backend/tests/semantic_harness.py
+++ b/backend/tests/semantic_harness.py
@@ -21,6 +21,10 @@ def execute_ir_workflow(workflow: IRWorkflow, inputs: dict[str, Any]) -> dict[st
         node = node_map[node_id]
         if node.node_type == IRNodeType.START:
             values[node.id] = dict(inputs)
+        elif node.node_type == IRNodeType.CODE:
+            arguments = {var.name: _resolve_ir_variable(values, var) for var in node.inputs}
+            values[node.id] = _execute_python_code(node.config.get("code", ""), arguments)
+            terminal = values[node.id]
         elif node.node_type == IRNodeType.OUTPUT_EMITTER:
             values[node.id] = {"answer": _build_ir_answer(node.inputs, values)}
             terminal = values[node.id]
@@ -44,6 +48,13 @@ def execute_dify_workflow(dsl: DifyDSL, inputs: dict[str, Any]) -> dict[str, Any
         node_type = node.data.type
         if node_type == "start":
             values[node.id] = dict(inputs)
+        elif node_type == "code":
+            arguments = {
+                entry["variable"]: _resolve_selector(values, entry.get("value_selector", []))
+                for entry in node.data.variables
+            }
+            values[node.id] = _execute_python_code(node.data.code, arguments)
+            terminal = values[node.id]
         elif node_type == "answer":
             values[node.id] = {"answer": _render_template(node.data.answer, values)}
             terminal = values[node.id]
@@ -119,3 +130,9 @@ def _render_template(template: str, values: dict[str, dict[str, Any]]) -> str:
         return str(_resolve_selector(values, parts) or "")
 
     return _TEMPLATE_RE.sub(replace, template)
+
+
+def _execute_python_code(code: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    namespace: dict[str, Any] = {}
+    exec(code, {}, namespace)  # noqa: S102 - fixtures are repo-local test inputs
+    return dict(namespace["main"](**arguments))

--- a/backend/tests/test_conversion_service.py
+++ b/backend/tests/test_conversion_service.py
@@ -10,6 +10,8 @@ from core.ir.types import IRNodeType, IRVariableType
 from db.database import Base
 from db.models import MigrationTask, SyncConfig
 
+from .coze_workflow_corpus import CORPUS_CASES
+
 
 MINIMAL_COZE_CANVAS = {
     "nodes": [
@@ -34,6 +36,8 @@ MINIMAL_COZE_CANVAS = {
     ],
     "versions": {},
 }
+
+MANUAL_REVIEW_COZE_CANVAS = next(case.canvas for case in CORPUS_CASES if case.name == "code_python_uppercase")
 
 
 def test_convert_uploaded_file_persists_artifacts(tmp_path) -> None:
@@ -277,3 +281,54 @@ def test_write_to_dify_persists_sanitized_failure_details(tmp_path, monkeypatch)
     assert persisted["error_message"] == "unable to connect to postgresql://***@dify.example:5432/dify"
     assert persisted["write_result"]["status"] == "failed"
     assert persisted["write_result"]["target"]["display_url"] == "postgresql://***@dify.example:5432/dify"
+
+
+def test_write_to_dify_requires_manual_review_confirmation(tmp_path, monkeypatch) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-write-manual-review.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    service = ConversionService()
+
+    class SuccessfulWriter:
+        def __init__(self, db_url: str) -> None:
+            self.db_url = db_url
+
+        def write_workflow(self, dify_dsl) -> str:  # noqa: ANN001 - test double
+            return "app-reviewed-123"
+
+    monkeypatch.setattr("core.engine.conversion_service.DifyDbWriter", SuccessfulWriter)
+
+    with session_factory() as db:
+        conversion = service.convert_uploaded_file(
+            db,
+            json.dumps(MANUAL_REVIEW_COZE_CANVAS).encode(),
+            "manual-review.json",
+        )
+
+        assert conversion["status"] == "converted"
+        assert conversion["report"]["supported"] is True
+        assert conversion["report"]["requires_manual_review"] is True
+
+        with pytest.raises(ValueError, match="manual review"):
+            service.write_to_dify(
+                db,
+                conversion["conversion_id"],
+                db_url="postgresql://writer:supersecret@dify.example:5432/dify",
+            )
+
+        write_result = service.write_to_dify(
+            db,
+            conversion["conversion_id"],
+            db_url="postgresql://writer:supersecret@dify.example:5432/dify",
+            confirm_reviewed=True,
+        )
+        persisted = service.get_conversion(db, conversion["conversion_id"])
+
+    assert write_result["status"] == "written"
+    assert write_result["write_result"]["status"] == "succeeded"
+    assert persisted["status"] == "written"
+    assert persisted["audit"]["last_write"]["app_id"] == "app-reviewed-123"
+    assert persisted["error_message"] is None

--- a/backend/tests/test_golden_snapshots.py
+++ b/backend/tests/test_golden_snapshots.py
@@ -18,6 +18,7 @@ def test_golden_snapshot_cases_exist() -> None:
         "baseline_start_end",
         "output_emitter_passthrough",
         "output_emitter_literal_supported_duplicate",
+        "code_python_uppercase",
     ]
 
 
@@ -28,6 +29,7 @@ def test_supported_cases_match_golden_yaml_snapshots(case) -> None:
     dsl, report = service.engine.convert_from_dict(case.canvas)
 
     assert report.supported is True
+    assert report.requires_manual_review is case.expected_manual_review
     assert dsl is not None
     expected_snapshot = yaml.safe_load((_SNAPSHOT_DIR / f"{case.golden_snapshot}.yml").read_text())
     actual_snapshot = yaml.safe_load(service.engine.dify_generator.to_yaml(dsl))

--- a/backend/tests/test_semantic_equivalence.py
+++ b/backend/tests/test_semantic_equivalence.py
@@ -17,6 +17,7 @@ def test_semantic_corpus_cases_exist() -> None:
         "output_emitter_passthrough",
         "output_emitter_literal_supported_duplicate",
         "comment_annotation",
+        "code_python_uppercase",
     ]
 
 
@@ -28,6 +29,7 @@ def test_supported_cases_match_ir_and_dify_terminal_semantics(case) -> None:
     dsl, report = service.engine.convert_from_ir(ir_workflow)
 
     assert report.supported is True
+    assert report.requires_manual_review is case.expected_manual_review
     assert dsl is not None
     assert execute_ir_workflow(ir_workflow, case.semantic_inputs) == case.expected_terminal
     assert execute_dify_workflow(dsl, case.semantic_inputs) == case.expected_terminal

--- a/backend/tests/test_strict_supported_subset_corpus.py
+++ b/backend/tests/test_strict_supported_subset_corpus.py
@@ -19,8 +19,13 @@ def test_strict_subset_corpus_matches_current_support_boundary(case) -> None:
     dsl, report = service.engine.convert_from_dict(case.canvas)
 
     assert report.supported is case.expected_supported
+    assert report.requires_manual_review is case.expected_manual_review
     assert (dsl is not None) is case.expected_supported
     if case.expected_supported:
         assert report.blocking_issues == []
+        if case.expected_manual_review:
+            assert report.manual_review_reasons
+        else:
+            assert report.manual_review_reasons == []
     else:
         assert report.blocking_issues

--- a/backend/tests/test_strict_supported_subset_policy.py
+++ b/backend/tests/test_strict_supported_subset_policy.py
@@ -9,6 +9,8 @@ from sqlalchemy.orm import sessionmaker
 from core.engine.conversion_service import ConversionService
 from db.database import Base
 
+from .coze_workflow_corpus import CORPUS_CASES
+
 
 _SUPPORTED_CANVAS = {
     "nodes": [
@@ -68,6 +70,8 @@ _BLOCKED_CANVAS = {
     "versions": {},
 }
 
+_MANUAL_REVIEW_CANVAS = next(case.canvas for case in CORPUS_CASES if case.name == "code_python_uppercase")
+
 
 def test_strict_subset_allows_supported_workflow() -> None:
     service = ConversionService()
@@ -89,6 +93,18 @@ def test_strict_subset_blocks_partial_or_unmappable_workflow() -> None:
     assert dsl is None
     assert report.blocking_issues
     assert report.node_results[1].support_state == "blocked"
+
+
+def test_strict_subset_admits_python_code_only_with_manual_review() -> None:
+    service = ConversionService()
+
+    dsl, report = service.engine.convert_from_dict(_MANUAL_REVIEW_CANVAS)
+
+    assert report.supported is True
+    assert report.requires_manual_review is True
+    assert report.manual_review_reasons
+    assert dsl is not None
+    assert report.node_results[1].support_state == "manual_review"
 
 
 def test_blocked_workflow_is_persisted_without_dsl_artifact(tmp_path) -> None:

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -112,6 +112,21 @@ class EmptyCozeReader:
         return None
 
 
+class ManualReviewPreviewCozeReader:
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+
+    def list_workflows(self) -> list[dict[str, str]]:
+        return [{"id": "wf-review", "name": "Manual Review Flow"}]
+
+    def read_workflow(self, workflow_id: str) -> dict[str, object] | None:
+        return {
+            "id": workflow_id,
+            "name": "Manual Review Flow",
+            "canvas": _manual_review_canvas(workflow_id),
+        }
+
+
 class DeletePreviewDifyReader:
     def __init__(self, db_url: str) -> None:
         self.db_url = db_url
@@ -231,6 +246,28 @@ class BlockedConversionService(FakeConversionService):
         }
 
 
+class ManualReviewConversionService(FakeConversionService):
+    def convert_from_db(self, db, *, db_url: str, workflow_id: str) -> dict[str, object]:
+        result = super().convert_from_db(db, db_url=db_url, workflow_id=workflow_id)
+        task = db.get(MigrationTask, int(result["conversion_id"]))
+        assert task is not None
+        task.report = {
+            "workflow_name": workflow_id,
+            "total_nodes": 3,
+            "supported": True,
+            "blocking_issues": [],
+            "requires_manual_review": True,
+            "manual_review_reasons": [
+                "Python code nodes are admitted only with mandatory manual review before write-to-Dify."
+            ],
+        }
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        result["report"] = task.report
+        return result
+
+
 def _minimal_canvas(node_id: str) -> dict[str, object]:
     start_id = f"{node_id}-start"
     end_id = f"{node_id}-end"
@@ -250,6 +287,82 @@ def _minimal_canvas(node_id: str) -> dict[str, object]:
             },
         ],
         "edges": [{"sourceNodeID": start_id, "targetNodeID": end_id}],
+        "versions": {},
+    }
+
+
+def _manual_review_canvas(node_id: str) -> dict[str, object]:
+    start_id = f"{node_id}-start"
+    code_id = f"{node_id}-code"
+    answer_id = f"{node_id}-answer"
+    return {
+        "nodes": [
+            {
+                "id": start_id,
+                "type": "1",
+                "meta": {"position": {"x": 0, "y": 0}},
+                "data": {"outputs": [{"type": "string", "name": "input", "required": True}]},
+            },
+            {
+                "id": code_id,
+                "type": "5",
+                "meta": {"position": {"x": 320, "y": 0}},
+                "data": {
+                    "inputs": {
+                        "language": 1,
+                        "code": "def main(value):\n    return {'result': value.upper()}\n",
+                        "inputParameters": [
+                            {
+                                "name": "value",
+                                "input": {
+                                    "type": "string",
+                                    "value": {
+                                        "type": "ref",
+                                        "content": {
+                                            "blockID": start_id,
+                                            "name": "input",
+                                            "path": [],
+                                            "source": "block-output",
+                                        },
+                                    },
+                                },
+                            }
+                        ],
+                        "outputParameters": [{"name": "result", "input": {"type": "string"}}],
+                    }
+                },
+            },
+            {
+                "id": answer_id,
+                "type": "13",
+                "meta": {"position": {"x": 640, "y": 0}},
+                "data": {
+                    "inputs": {
+                        "inputParameters": [
+                            {
+                                "name": "answer",
+                                "input": {
+                                    "type": "string",
+                                    "value": {
+                                        "type": "ref",
+                                        "content": {
+                                            "blockID": code_id,
+                                            "name": "result",
+                                            "path": [],
+                                            "source": "block-output",
+                                        },
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                },
+            },
+        ],
+        "edges": [
+            {"sourceNodeID": start_id, "targetNodeID": code_id},
+            {"sourceNodeID": code_id, "targetNodeID": answer_id},
+        ],
         "versions": {},
     }
 
@@ -594,6 +707,93 @@ def test_execute_sync_skips_write_for_blocked_conversions(tmp_path) -> None:
     assert conversion_service.write_calls == []
     assert len(synced_tasks) == 1
     assert synced_tasks[0].status == "blocked"
+
+
+def test_execute_sync_blocks_manual_review_workflows_from_automated_write(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-manual-review.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    conversion_service = ManualReviewConversionService()
+    sync_engine = SyncEngine(
+        conversion_service,
+        coze_reader_factory=ManualReviewPreviewCozeReader,
+        dify_reader_factory=EmptyDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Manual Review Sync",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        result = sync_engine.execute_sync(db, config)
+        synced_tasks = (
+            db.execute(select(MigrationTask).where(MigrationTask.sync_config_id == config.id)).scalars().all()
+        )
+
+    assert result["status"] == "partial"
+    assert result["summary"] == {
+        "created": 0,
+        "updated": 0,
+        "failed": 0,
+        "skipped": 0,
+        "unsupported": 1,
+        "conflicts": 0,
+    }
+    assert result["items"][0]["status"] == "unsupported"
+    assert "manual review" in result["items"][0]["message"].lower()
+    assert conversion_service.write_calls == []
+    assert len(synced_tasks) == 1
+    assert synced_tasks[0].status == "converted"
+
+
+def test_preview_diff_marks_manual_review_workflows_as_unsupported(tmp_path) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'coze2dify-sync-preview-manual-review.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+    sync_engine = SyncEngine(
+        ConversionService(),
+        coze_reader_factory=ManualReviewPreviewCozeReader,
+        dify_reader_factory=EmptyDifyReader,
+    )
+
+    with session_factory() as db:
+        config = SyncConfig(
+            name="Preview Manual Review",
+            coze_db_url="postgresql://coze.test/app",
+            dify_db_url="postgresql://dify.test/app",
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+
+        result = sync_engine.preview_diff(db, config)
+        persisted_tasks = db.execute(select(MigrationTask)).scalars().all()
+
+    assert result["status"] == "partial"
+    assert result["summary"] == {
+        "created": 0,
+        "updated": 0,
+        "failed": 0,
+        "skipped": 0,
+        "unsupported": 1,
+        "conflicts": 0,
+    }
+    assert result["items"][0]["source_workflow_id"] == "wf-review"
+    assert result["items"][0]["status"] == "unsupported"
+    assert "manual review" in result["items"][0]["message"].lower()
+    assert persisted_tasks == []
 
 
 def test_resolve_conflict_source_wins_updates_history_and_persists_resolution(tmp_path) -> None:

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,7 +136,9 @@ The report now includes:
 
 - `support_mode`
 - `supported`
+- `requires_manual_review`
 - `blocking_issues`
+- `manual_review_reasons`
 
 ### `GET /convert/{id}/dsl`
 
@@ -152,9 +154,19 @@ Get detailed conversion report (mapping stats, warnings, unmappable nodes).
 
 Direct-write conversion result to Dify PostgreSQL.
 
+**Request:**
+```json
+{
+  "db_url": "postgresql://user:pass@host:5432/dify",
+  "app_id": "optional-existing-app-id",
+  "confirm_reviewed": false
+}
+```
+
 Safety behavior:
 
 - blocked conversions are rejected before any write is attempted
+- conversions marked `requires_manual_review = true` are rejected unless `confirm_reviewed = true`
 - raw target DB URLs are not echoed back in API-visible payloads
 - successful and failed writes persist redacted target references plus last-write audit metadata
 - write failures return actionable, sanitized error details

--- a/docs/supported-subset.md
+++ b/docs/supported-subset.md
@@ -11,6 +11,12 @@ The goal is conservative correctness: only a small verified subset of Coze workf
 - OutputEmitter (`type: 13`) -> `answer`
 - Comment (`type: 31`) -> skipped safely, no Dify node emitted
 
+### Supported only with mandatory manual review
+
+- Python CodeRunner (`type: 5`, `language: python3`) -> `code`
+
+These workflows are converted and can be downloaded as DSL, but direct write to Dify is blocked until the operator explicitly confirms manual review.
+
 ## What Is Blocked
 
 The strict subset blocks:
@@ -28,3 +34,10 @@ Blocked conversions:
 
 This policy is intentionally conservative. The subset should only expand when dedicated coverage is added for the new path.
 The current coverage baseline lives in `backend/tests/coze_workflow_corpus.py` and tracks 42 representative Coze node-class cases.
+
+Coverage expectations for each admitted path now include:
+
+1. Corpus coverage in `backend/tests/coze_workflow_corpus.py`.
+2. Golden YAML snapshots for every currently supported mapping in `backend/tests/golden/strict_supported_subset/`.
+3. Semantic equivalence tests for supported workflows, comparing IR execution and generated Dify DSL execution on the same inputs.
+4. Service and sync-path tests that verify blocked/manual-review workflows cannot slip through persistence or automated write paths.

--- a/frontend/src/api/conversion.ts
+++ b/frontend/src/api/conversion.ts
@@ -50,7 +50,7 @@ export async function getReport(conversionId: string) {
 
 export async function writeToDify(
   conversionId: string,
-  payload: { db_url?: string; app_id?: string },
+  payload: { db_url?: string; app_id?: string; confirm_reviewed?: boolean },
 ): Promise<{ conversion_id: string; app_id: string | null; mode: "create" | "update"; status: string; write_result: WriteResult }> {
   const resp = await client.post(`/convert/${conversionId}/write-to-dify`, payload);
   return resp.data;

--- a/frontend/src/components/history/ConversionHistoryTable.tsx
+++ b/frontend/src/components/history/ConversionHistoryTable.tsx
@@ -134,10 +134,18 @@ export default function ConversionHistoryTable({ items }: { items: ConversionHis
                       <span
                         style={{
                           fontSize: "0.74rem",
-                          color: !report.supported ? "var(--c-red)" : "var(--c-text-tertiary)",
+                          color: !report.supported
+                            ? "var(--c-red)"
+                            : report.requires_manual_review
+                              ? "var(--c-amber)"
+                              : "var(--c-text-tertiary)",
                         }}
                       >
-                        {report.supported ? "Inside strict subset" : "Strict subset blocked"}
+                        {!report.supported
+                          ? "Strict subset blocked"
+                          : report.requires_manual_review
+                            ? "Manual review required"
+                            : "Inside strict subset"}
                       </span>
                     </div>
                   ) : (

--- a/frontend/src/components/result/DirectWriteButton.tsx
+++ b/frontend/src/components/result/DirectWriteButton.tsx
@@ -14,12 +14,21 @@ export default function DirectWriteButton({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [result, setResult] = useState<WriteResult | null>(null);
+  const [reviewConfirmed, setReviewConfirmed] = useState(false);
   const blockedReason =
     report.blocking_issues[0] || "This workflow is outside the strict supported subset.";
+  const manualReviewReason =
+    report.manual_review_reasons[0] || "Manual review is required before write-to-Dify.";
+  const isBlocked = !report.supported;
+  const requiresManualReview = report.requires_manual_review;
 
   const handleWrite = async () => {
-    if (!report.supported) {
+    if (isBlocked) {
       setError(blockedReason);
+      return;
+    }
+    if (requiresManualReview && !reviewConfirmed) {
+      setError(manualReviewReason);
       return;
     }
     setLoading(true);
@@ -28,6 +37,7 @@ export default function DirectWriteButton({
       const response = await writeToDify(conversionId, {
         db_url: difyDbUrl || undefined,
         app_id: difySelectedAppId || undefined,
+        confirm_reviewed: requiresManualReview ? reviewConfirmed : undefined,
       });
       setResult(response.write_result);
     } catch (e: any) {
@@ -42,11 +52,39 @@ export default function DirectWriteButton({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 6 }}>
-      <button className="btn btn-secondary" onClick={handleWrite} disabled={loading || !report.supported}>
+      {requiresManualReview && (
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: "0.76rem",
+            color: "var(--c-text-secondary)",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={reviewConfirmed}
+            onChange={(event) => {
+              setReviewConfirmed(event.target.checked);
+              setError("");
+            }}
+          />
+          I reviewed the migrated workflow and approve the direct write.
+        </label>
+      )}
+      <button
+        className="btn btn-secondary"
+        onClick={handleWrite}
+        disabled={loading || isBlocked || (requiresManualReview && !reviewConfirmed)}
+      >
         {loading ? "Writing..." : difySelectedAppId ? "🗄 Update Dify App" : "🗄 Write to Dify DB"}
       </button>
-      {!error && !report.supported && (
+      {!error && isBlocked && (
         <span style={{ fontSize: "0.72rem", color: "var(--c-red)" }}>{blockedReason}</span>
+      )}
+      {!error && !isBlocked && requiresManualReview && (
+        <span style={{ fontSize: "0.72rem", color: "var(--c-amber)" }}>{manualReviewReason}</span>
       )}
       {result && (
         <div style={{ display: "grid", gap: 2 }}>

--- a/frontend/src/components/result/WarningList.tsx
+++ b/frontend/src/components/result/WarningList.tsx
@@ -32,10 +32,20 @@ export default function WarningList({ results }: { results: NodeConversionResult
             {r.support_state === "blocked" && (
               <span style={{ color: "var(--c-red)", marginLeft: 8 }}>— Blocked</span>
             )}
+            {r.support_state === "manual_review" && (
+              <span style={{ color: "var(--c-amber)", marginLeft: 8 }}>— Manual review</span>
+            )}
             {[...new Set([...r.support_reasons, ...r.warnings, ...r.errors])].map((message, i) => (
               <span
                 key={`${r.source_node_id}-${i}`}
-                style={{ marginLeft: 8, color: r.support_state === "blocked" ? "var(--c-red)" : undefined }}
+                style={{
+                  marginLeft: 8,
+                  color: r.support_state === "blocked"
+                    ? "var(--c-red)"
+                    : r.support_state === "manual_review"
+                      ? "var(--c-amber)"
+                      : undefined,
+                }}
               >
                 — {message || (r.status === "unmappable" ? "No Dify equivalent" : "Review required")}
               </span>

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -91,9 +91,13 @@ export default function ResultPage() {
 
   const blockedReason =
     activeReport.blocking_issues[0] || "This workflow is outside the strict supported subset.";
+  const manualReviewReason =
+    activeReport.manual_review_reasons[0] || "Manual review is required before write-to-Dify.";
   const exportDescription = !activeReport.supported
     ? "Blocked workflows do not emit Dify DSL. Resolve the listed nodes before exporting."
-    : t("result.exportOptionsDesc");
+    : activeReport.requires_manual_review
+      ? "DSL download is available, but direct write stays locked until manual review is confirmed."
+      : t("result.exportOptionsDesc");
 
   return (
     <PageShell
@@ -109,6 +113,16 @@ export default function ResultPage() {
           <div style={{ marginTop: 6 }}>{blockedReason}</div>
           <div style={{ marginTop: 6, fontSize: "0.78rem" }}>
             No Dify DSL was generated for this conversion, so export actions are disabled.
+          </div>
+        </div>
+      )}
+
+      {activeReport.supported && activeReport.requires_manual_review && (
+        <div className="alert alert--warning" style={{ marginTop: 24 }}>
+          <strong>Manual review required before direct write.</strong>
+          <div style={{ marginTop: 6 }}>{manualReviewReason}</div>
+          <div style={{ marginTop: 6, fontSize: "0.78rem" }}>
+            Download remains available. Direct write unlocks only after explicit operator confirmation.
           </div>
         </div>
       )}

--- a/frontend/src/types/ir.ts
+++ b/frontend/src/types/ir.ts
@@ -1,7 +1,7 @@
 import type { DatabaseTargetRef } from "./audit";
 
 export type MappingStatus = "mapped" | "partial" | "unmappable" | "skipped";
-export type SupportState = "supported" | "blocked";
+export type SupportState = "supported" | "blocked" | "manual_review";
 
 export interface NodeConversionResult {
   source_node_id: string;
@@ -18,7 +18,9 @@ export interface NodeConversionResult {
 export interface ConversionReport {
   support_mode: "strict_supported_subset";
   supported: boolean;
+  requires_manual_review: boolean;
   blocking_issues: string[];
+  manual_review_reasons: string[];
   workflow_name: string;
   total_nodes: number;
   mapped_count: number;
@@ -87,6 +89,7 @@ export interface ConversionAudit {
 export interface ConversionHistoryReportSummary {
   workflow_name: string;
   supported: boolean;
+  requires_manual_review: boolean;
   total_nodes: number;
   mapped_count: number;
   partial_count: number;


### PR DESCRIPTION
## Why
Python `CodeRunner` nodes are high-risk: they are valuable enough to admit into the supported subset, but unsafe enough that direct write and sync paths must not push them into Dify without an explicit human review step.

## What Changed
- admit Python `CodeRunner` nodes into the strict supported subset under a `manual_review` state instead of treating them as fully supported or fully blocked
- require explicit `confirm_reviewed` before `write-to-dify`, and block automated sync, preview, and conflict-write paths from bypassing that gate
- surface the review requirement in the result page, direct-write control, history table, docs, corpus, semantic tests, golden snapshots, and backend service/sync regression coverage

## Verification
- `./scripts/ci-local.sh`
- `backend/.venv/bin/pytest backend/tests/test_strict_supported_subset_policy.py backend/tests/test_strict_supported_subset_corpus.py backend/tests/test_semantic_equivalence.py backend/tests/test_golden_snapshots.py backend/tests/test_conversion_service.py backend/tests/test_sync_engine.py`
- `backend/.venv/bin/ruff check backend`
- `cd frontend && npm run build`
- GitHub Actions: backend lint, backend tests (3.10/3.11/3.12), PostgreSQL integration, frontend checks, and E2E smoke

Closes #45
