### PR TITLE
feat: add 1:1 Migration QA workbench frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useLocation } from "react-router-dom";
 import { AppRoutes } from "./routes";
 import Header from "./components/layout/Header";
 import { ToastProvider } from "./components/common/Toast";
@@ -7,13 +7,34 @@ export default function App() {
   return (
     <BrowserRouter>
       <ToastProvider>
-        <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
-          <Header />
-          <main style={{ flex: 1, maxWidth: 1280, width: "100%", margin: "0 auto", padding: "32px 24px" }}>
-            <AppRoutes />
-          </main>
-        </div>
+        <AppFrame />
       </ToastProvider>
     </BrowserRouter>
+  );
+}
+
+function AppFrame() {
+  const location = useLocation();
+  const isWorkbench = location.pathname.startsWith("/workbench");
+
+  if (isWorkbench) {
+    return <AppRoutes />;
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+      <Header />
+      <main
+        style={{
+          flex: 1,
+          maxWidth: 1280,
+          width: "100%",
+          margin: "0 auto",
+          padding: "32px 24px",
+        }}
+      >
+        <AppRoutes />
+      </main>
+    </div>
   );
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -8,12 +8,14 @@ import {
   History,
   Settings,
   Globe,
+  FlaskConical,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 const NAV_ITEMS: Array<{ to: string; labelKey: string; icon: LucideIcon }> = [
   { to: "/", labelKey: "nav.dashboard", icon: LayoutDashboard },
   { to: "/migrate", labelKey: "nav.migrate", icon: ArrowRightLeft },
+  { to: "/workbench", labelKey: "nav.workbench", icon: FlaskConical },
   { to: "/sync", labelKey: "nav.sync", icon: RefreshCw },
   { to: "/history", labelKey: "nav.history", icon: History },
   { to: "/settings", labelKey: "nav.settings", icon: Settings },

--- a/frontend/src/features/migrationWorkbench/components/DagGraph.tsx
+++ b/frontend/src/features/migrationWorkbench/components/DagGraph.tsx
@@ -1,0 +1,87 @@
+import { useId } from "react";
+import { C, NODE_COLORS, NODE_ICONS } from "../theme";
+import type { DagGraphData } from "../types";
+
+interface DagGraphProps {
+  graph: DagGraphData;
+  platform: "coze" | "dify";
+}
+
+export default function DagGraph({ graph, platform }: DagGraphProps) {
+  const markerId = useId();
+  const stroke = platform === "coze" ? C.coze : C.dify;
+
+  return (
+    <svg width="100%" viewBox="0 0 980 320" role="img" aria-label={`${platform} dag`}>
+      <defs>
+        <marker
+          id={markerId}
+          markerWidth="8"
+          markerHeight="6"
+          refX="8"
+          refY="3"
+          orient="auto"
+        >
+          <polygon points="0 0,8 3,0 6" fill={stroke} opacity="0.55" />
+        </marker>
+      </defs>
+
+      {graph.edges.map(([fromId, toId], index) => {
+        const fromNode = graph.nodes.find((node) => node.id === fromId);
+        const toNode = graph.nodes.find((node) => node.id === toId);
+
+        if (!fromNode || !toNode) {
+          return null;
+        }
+
+        const startX = fromNode.x + 55;
+        const endX = toNode.x - 5;
+        const controlX = (startX + endX) / 2;
+
+        return (
+          <path
+            key={`${fromId}-${toId}-${index}`}
+            d={`M${startX},${fromNode.y} C${controlX},${fromNode.y} ${controlX},${toNode.y} ${endX},${toNode.y}`}
+            fill="none"
+            markerEnd={`url(#${markerId})`}
+            opacity="0.4"
+            stroke={stroke}
+            strokeWidth="1.6"
+          />
+        );
+      })}
+
+      {graph.nodes.map((node) => {
+        const color = NODE_COLORS[node.type];
+        const icon = NODE_ICONS[node.type];
+
+        return (
+          <g key={node.id}>
+            <rect
+              x={node.x - 5}
+              y={node.y - 18}
+              width={110}
+              height={36}
+              rx={7}
+              fill={C.s1}
+              stroke={color}
+              strokeWidth="1"
+              opacity="0.9"
+            />
+            <text
+              x={node.x + 8}
+              y={node.y + 2}
+              fontSize="10"
+              fill={C.tx}
+              fontFamily={C.ft}
+              dominantBaseline="middle"
+              fontWeight="500"
+            >
+              {icon} {node.label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/Panel.tsx
+++ b/frontend/src/features/migrationWorkbench/components/Panel.tsx
@@ -1,0 +1,21 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface PanelProps {
+  children: ReactNode;
+  style?: CSSProperties;
+}
+
+export default function Panel({ children, style }: PanelProps) {
+  return (
+    <div
+      style={{
+        background: "#0c1221",
+        border: "1px solid #1c2a48",
+        borderRadius: 8,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/ProgressBar.tsx
+++ b/frontend/src/features/migrationWorkbench/components/ProgressBar.tsx
@@ -1,0 +1,47 @@
+import { C } from "../theme";
+import type { Tone } from "../types";
+import { progressPercent } from "../utils";
+
+interface ProgressBarProps {
+  value: number;
+  total: number;
+  tone?: Tone;
+}
+
+export default function ProgressBar({
+  value,
+  total,
+  tone = "accent",
+}: ProgressBarProps) {
+  const width = progressPercent(value, total);
+  const color = {
+    accent: C.acc,
+    info: C.coze,
+    success: C.ok,
+    warning: C.warn,
+    danger: C.err,
+    muted: C.tx2,
+  }[tone];
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: 5,
+        borderRadius: 3,
+        background: C.bd,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          width: `${width}%`,
+          height: "100%",
+          borderRadius: 3,
+          background: color,
+          transition: "width .5s",
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/SectionHeader.tsx
+++ b/frontend/src/features/migrationWorkbench/components/SectionHeader.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+interface SectionHeaderProps {
+  children: ReactNode;
+  action?: ReactNode;
+}
+
+export default function SectionHeader({ children, action }: SectionHeaderProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: 14,
+      }}
+    >
+      <h2 style={{ fontSize: 14, fontWeight: 700, margin: 0 }}>{children}</h2>
+      {action}
+    </div>
+  );
+}
+

--- a/frontend/src/features/migrationWorkbench/components/SegmentTabs.tsx
+++ b/frontend/src/features/migrationWorkbench/components/SegmentTabs.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { C } from "../theme";
+
+interface SegmentTabItem<T extends string> {
+  key: T;
+  label: string;
+  icon?: ReactNode;
+}
+
+interface SegmentTabsProps<T extends string> {
+  items: Array<SegmentTabItem<T>>;
+  activeKey: T;
+  onChange: (key: T) => void;
+}
+
+export default function SegmentTabs<T extends string>({
+  items,
+  activeKey,
+  onChange,
+}: SegmentTabsProps<T>) {
+  return (
+    <div style={{ display: "flex", gap: 1, borderBottom: `1px solid ${C.bd}` }}>
+      {items.map((item) => (
+        <button
+          key={item.key}
+          onClick={() => onChange(item.key)}
+          style={{
+            padding: "8px 14px",
+            fontSize: 12,
+            fontWeight: activeKey === item.key ? 600 : 400,
+            fontFamily: C.ft,
+            background: "transparent",
+            border: "none",
+            borderBottom:
+              activeKey === item.key
+                ? `2px solid ${C.acc}`
+                : "2px solid transparent",
+            color: activeKey === item.key ? C.acc : C.tx2,
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+          type="button"
+        >
+          {item.icon}
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/SidebarNav.tsx
+++ b/frontend/src/features/migrationWorkbench/components/SidebarNav.tsx
@@ -1,0 +1,145 @@
+import { C, WORKBENCH_NAV } from "../theme";
+import type { WorkbenchPageKey, WorkflowSummary } from "../types";
+
+interface SidebarNavProps {
+  activePage: WorkbenchPageKey;
+  onNavigate: (page: WorkbenchPageKey) => void;
+  workflows: WorkflowSummary[];
+  selectedWorkflowId: string;
+  onWorkflowSelect: (workflowId: string) => void;
+}
+
+export default function SidebarNav({
+  activePage,
+  onNavigate,
+  workflows,
+  selectedWorkflowId,
+  onWorkflowSelect,
+}: SidebarNavProps) {
+  const groups = Array.from(new Set(WORKBENCH_NAV.map((item) => item.group)));
+
+  return (
+    <div
+      style={{
+        width: 200,
+        background: C.s1,
+        borderRight: `1px solid ${C.bd}`,
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: 0,
+      }}
+    >
+      <div style={{ padding: "14px 14px 16px", borderBottom: `1px solid ${C.bd}` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div
+            style={{
+              width: 26,
+              height: 26,
+              borderRadius: 6,
+              background: `linear-gradient(135deg,${C.acc},${C.dify})`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 12,
+              fontWeight: 800,
+              color: "#fff",
+            }}
+          >
+            M
+          </div>
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 700 }}>MigrationQA</div>
+            <div style={{ fontSize: 8, color: C.tx3, fontFamily: C.mono }}>
+              v2.0 · Coze→Dify
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <nav style={{ padding: "8px 6px", flex: 1, overflow: "auto" }}>
+        {groups.map((group) => (
+          <div key={group} style={{ marginBottom: 6 }}>
+            <div
+              style={{
+                padding: "3px 8px",
+                fontSize: 9,
+                fontWeight: 700,
+                color: C.tx3,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+              }}
+            >
+              {group}
+            </div>
+            {WORKBENCH_NAV.filter((item) => item.group === group).map((item) => {
+              const active = activePage === item.key;
+
+              return (
+                <button
+                  key={item.key}
+                  onClick={() => onNavigate(item.key)}
+                  style={{
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "6px 9px",
+                    marginBottom: 1,
+                    borderRadius: 4,
+                    border: "none",
+                    background: active ? C.accD : "transparent",
+                    color: active ? C.acc : C.tx2,
+                    fontSize: 11,
+                    fontWeight: active ? 600 : 400,
+                    fontFamily: C.ft,
+                    cursor: "pointer",
+                    textAlign: "left",
+                  }}
+                  type="button"
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </nav>
+
+      <div style={{ padding: 8, borderTop: `1px solid ${C.bd}` }}>
+        <div
+          style={{
+            fontSize: 8,
+            fontWeight: 700,
+            color: C.tx3,
+            textTransform: "uppercase",
+            padding: "0 5px 4px",
+          }}
+        >
+          当前工作流
+        </div>
+        <select
+          value={selectedWorkflowId}
+          onChange={(event) => onWorkflowSelect(event.target.value)}
+          style={{
+            width: "100%",
+            padding: "6px 8px",
+            borderRadius: 4,
+            background: C.s2,
+            border: `1px solid ${C.bd}`,
+            color: C.tx,
+            fontSize: 10,
+            fontFamily: C.ft,
+            cursor: "pointer",
+            outline: "none",
+          }}
+        >
+          {workflows.map((workflow) => (
+            <option key={workflow.id} value={workflow.id}>
+              {workflow.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/StatusBadge.tsx
+++ b/frontend/src/features/migrationWorkbench/components/StatusBadge.tsx
@@ -1,0 +1,41 @@
+import type { CSSProperties, ReactNode } from "react";
+import { C } from "../theme";
+import type { Tone } from "../types";
+
+interface StatusBadgeProps {
+  tone: Tone;
+  children: ReactNode;
+  style?: CSSProperties;
+}
+
+const TONE_COLORS: Record<Tone, string> = {
+  accent: C.acc,
+  info: C.coze,
+  success: C.ok,
+  warning: C.warn,
+  danger: C.err,
+  muted: C.tx2,
+};
+
+export default function StatusBadge({ tone, children, style }: StatusBadgeProps) {
+  const color = TONE_COLORS[tone];
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        padding: "2px 7px",
+        borderRadius: 4,
+        fontSize: 10,
+        fontWeight: 700,
+        color,
+        background: `${color}18`,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/WorkbenchButton.tsx
+++ b/frontend/src/features/migrationWorkbench/components/WorkbenchButton.tsx
@@ -1,0 +1,48 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { C } from "../theme";
+
+type WorkbenchButtonVariant = "primary" | "secondary" | "success" | "danger";
+
+interface WorkbenchButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: WorkbenchButtonVariant;
+  compact?: boolean;
+  children: ReactNode;
+}
+
+export default function WorkbenchButton({
+  variant = "secondary",
+  compact = false,
+  children,
+  style,
+  ...props
+}: WorkbenchButtonProps) {
+  const scheme = {
+    secondary: { bg: C.s2, bd: C.bdL, c: C.tx },
+    primary: { bg: C.accD, bd: `${C.acc}40`, c: C.acc },
+    success: { bg: C.okD, bd: `${C.ok}40`, c: C.ok },
+    danger: { bg: C.errD, bd: `${C.err}40`, c: C.err },
+  }[variant];
+
+  return (
+    <button
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        padding: compact ? "3px 9px" : "6px 13px",
+        fontSize: compact ? 11 : 12,
+        fontWeight: 600,
+        fontFamily: C.ft,
+        background: scheme.bg,
+        border: `1px solid ${scheme.bd}`,
+        borderRadius: 5,
+        color: scheme.c,
+        cursor: "pointer",
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/WorkbenchShell.tsx
+++ b/frontend/src/features/migrationWorkbench/components/WorkbenchShell.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { C, STATUS_MAP } from "../theme";
+import type { WorkbenchPageKey, WorkflowSummary } from "../types";
+import SidebarNav from "./SidebarNav";
+import StatusBadge from "./StatusBadge";
+
+interface WorkbenchShellProps {
+  activePage: WorkbenchPageKey;
+  onNavigate: (page: WorkbenchPageKey) => void;
+  workflows: WorkflowSummary[];
+  selectedWorkflow: WorkflowSummary;
+  onWorkflowSelect: (workflowId: string) => void;
+  children: ReactNode;
+}
+
+export default function WorkbenchShell({
+  activePage,
+  onNavigate,
+  workflows,
+  selectedWorkflow,
+  onWorkflowSelect,
+  children,
+}: WorkbenchShellProps) {
+  const statusMeta = STATUS_MAP[selectedWorkflow.status];
+
+  return (
+    <div
+      style={{
+        fontFamily: C.ft,
+        background: C.bg,
+        color: C.tx,
+        minHeight: "100vh",
+        display: "flex",
+        fontSize: 13,
+        lineHeight: 1.5,
+      }}
+    >
+      <SidebarNav
+        activePage={activePage}
+        onNavigate={onNavigate}
+        workflows={workflows}
+        selectedWorkflowId={selectedWorkflow.id}
+        onWorkflowSelect={onWorkflowSelect}
+      />
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <div
+          style={{
+            padding: "7px 22px",
+            borderBottom: `1px solid ${C.bd}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            background: C.s1,
+            flexShrink: 0,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+            {activePage !== "dashboard" && (
+              <>
+                <StatusBadge tone={statusMeta.tone}>{statusMeta.label}</StatusBadge>
+                <span style={{ fontSize: 12, fontWeight: 500 }}>{selectedWorkflow.name}</span>
+                <span style={{ fontSize: 9, color: C.tx3, fontFamily: C.mono }}>
+                  {selectedWorkflow.cozeId} → {selectedWorkflow.difyId ?? "—"}
+                </span>
+              </>
+            )}
+          </div>
+          <span style={{ fontSize: 9, color: C.tx3 }}>
+            {new Date().toLocaleDateString("zh-CN")}
+          </span>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "18px 22px" }}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/components/icons.tsx
+++ b/frontend/src/features/migrationWorkbench/components/icons.tsx
@@ -1,0 +1,35 @@
+export function IcCheck() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export function IcX() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+export function IcWarn() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+export function IcArrow() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/mockData.ts
+++ b/frontend/src/features/migrationWorkbench/mockData.ts
@@ -1,0 +1,393 @@
+import type {
+  CanaryStage,
+  DagGraphData,
+  ErrorPattern,
+  KnowledgeBaseRecord,
+  LiveMetric,
+  NodeComparison,
+  PluginCompatibilityItem,
+  PromptDiffData,
+  ReviewItem,
+  RollbackVersion,
+  StructureDiffItem,
+  TestCase,
+  VariableMapping,
+  WorkflowSummary,
+} from "./types";
+
+export const WORKFLOWS: WorkflowSummary[] = [
+  {
+    id: "wf1",
+    name: "智能客服助手",
+    cozeId: "bot_abc123",
+    difyId: "app-xyz789",
+    status: "migrated",
+    nodes: 12,
+    migrated: 11,
+    failed: 1,
+    score: 91.7,
+    complexity: "high",
+    lastSync: "2026-03-11",
+  },
+  {
+    id: "wf2",
+    name: "数据分析 Pipeline",
+    cozeId: "bot_def456",
+    difyId: "app-uvw321",
+    status: "testing",
+    nodes: 8,
+    migrated: 8,
+    failed: 0,
+    score: 98.5,
+    complexity: "medium",
+    lastSync: "2026-03-12",
+  },
+  {
+    id: "wf3",
+    name: "文档摘要生成器",
+    cozeId: "bot_ghi789",
+    difyId: null,
+    status: "pending",
+    nodes: 6,
+    migrated: 0,
+    failed: 0,
+    score: 0,
+    complexity: "low",
+    lastSync: null,
+  },
+  {
+    id: "wf4",
+    name: "多轮对话引擎",
+    cozeId: "bot_jkl012",
+    difyId: "app-rst654",
+    status: "verified",
+    nodes: 18,
+    migrated: 18,
+    failed: 0,
+    score: 99.2,
+    complexity: "high",
+    lastSync: "2026-03-10",
+  },
+  {
+    id: "wf5",
+    name: "RAG 知识库问答",
+    cozeId: "bot_mno345",
+    difyId: "app-opq987",
+    status: "failed",
+    nodes: 15,
+    migrated: 10,
+    failed: 5,
+    score: 66.7,
+    complexity: "high",
+    lastSync: "2026-03-12",
+  },
+];
+
+export const DAG_COZE: DagGraphData = {
+  nodes: [
+    { id: "c1", type: "start", label: "用户输入", x: 60, y: 160 },
+    { id: "c2", type: "llm", label: "意图识别", x: 220, y: 90 },
+    { id: "c3", type: "knowledge", label: "知识库", x: 220, y: 230 },
+    { id: "c4", type: "condition", label: "路由", x: 400, y: 160 },
+    { id: "c5", type: "code", label: "数据处理", x: 560, y: 90 },
+    { id: "c6", type: "http", label: "CRM API", x: 560, y: 230 },
+    { id: "c7", type: "llm", label: "回复生成", x: 720, y: 160 },
+    { id: "c8", type: "end", label: "输出", x: 870, y: 160 },
+  ],
+  edges: [
+    ["c1", "c2"],
+    ["c1", "c3"],
+    ["c2", "c4"],
+    ["c3", "c4"],
+    ["c4", "c5"],
+    ["c4", "c6"],
+    ["c5", "c7"],
+    ["c6", "c7"],
+    ["c7", "c8"],
+  ],
+};
+
+export const DAG_DIFY: DagGraphData = {
+  nodes: [
+    { id: "d1", type: "start", label: "开始", x: 50, y: 160 },
+    { id: "d2", type: "llm", label: "意图分类", x: 190, y: 90 },
+    { id: "d3", type: "knowledge", label: "知识检索", x: 190, y: 230 },
+    { id: "d4", type: "condition", label: "IF/ELSE", x: 350, y: 160 },
+    { id: "d5", type: "code", label: "代码执行", x: 500, y: 90 },
+    { id: "d6", type: "http", label: "HTTP请求", x: 500, y: 230 },
+    { id: "d7", type: "variable", label: "变量聚合", x: 640, y: 160 },
+    { id: "d8", type: "llm", label: "LLM生成", x: 790, y: 160 },
+    { id: "d9", type: "end", label: "结束", x: 920, y: 160 },
+  ],
+  edges: [
+    ["d1", "d2"],
+    ["d1", "d3"],
+    ["d2", "d4"],
+    ["d3", "d4"],
+    ["d4", "d5"],
+    ["d4", "d6"],
+    ["d5", "d7"],
+    ["d6", "d7"],
+    ["d7", "d8"],
+    ["d8", "d9"],
+  ],
+};
+
+export const STRUCTURE_DIFFS: StructureDiffItem[] = [
+  { text: "Dify 新增「变量聚合」节点", sev: "medium" },
+  { text: "HTTP 节点认证方式不同", sev: "high" },
+  { text: "路由→IF/ELSE 语法差异", sev: "low" },
+];
+
+export const NODE_COMPARISONS: NodeComparison[] = [
+  {
+    id: "n1",
+    type: "llm",
+    name: "LLM 主模型",
+    cCfg: { model: "gpt-4o", temperature: 0.7 },
+    dCfg: { model: "gpt-4o", temperature: 0.7 },
+    status: "equivalent",
+    diff: [],
+  },
+  {
+    id: "n2",
+    type: "knowledge",
+    name: "知识库检索",
+    cCfg: { dataset: "product_faq", topK: 5 },
+    dCfg: { dataset_id: "ds-001", top_k: 5 },
+    status: "equivalent",
+    diff: [],
+  },
+  {
+    id: "n3",
+    type: "code",
+    name: "数据预处理",
+    cCfg: { language: "python" },
+    dCfg: { language: "python3" },
+    status: "warning",
+    diff: [{ field: "language", coze: "python", dify: "python3", sev: "low" }],
+  },
+  {
+    id: "n4",
+    type: "http",
+    name: "CRM 接口",
+    cCfg: { method: "POST", auth: "headers" },
+    dCfg: { method: "POST", auth: "auth_object" },
+    status: "error",
+    diff: [
+      {
+        field: "auth",
+        coze: "headers",
+        dify: "auth object",
+        sev: "high",
+      },
+    ],
+  },
+];
+
+export const PROMPT_DIFF: PromptDiffData = {
+  coze: [
+    { ln: 1, text: "# Role", t: "same" },
+    { ln: 2, text: "你是专业的智能客服助手。", t: "same" },
+    { ln: 3, text: "", t: "same" },
+    { ln: 4, text: "# 核心能力", t: "same" },
+    { ln: 5, text: "- 产品咨询：回答功能、价格", t: "same" },
+    { ln: 6, text: "- 投诉处理：记录并转交人工", t: "removed" },
+    { ln: 7, text: "", t: "same" },
+    { ln: 8, text: "# 约束", t: "same" },
+    { ln: 9, text: "- 不确定时回复「需要确认」", t: "removed" },
+    { ln: 10, text: "- 回复不超200字", t: "same" },
+  ],
+  dify: [
+    { ln: 1, text: "# Role", t: "same" },
+    { ln: 2, text: "你是专业的智能客服助手。", t: "same" },
+    { ln: 3, text: "", t: "same" },
+    { ln: 4, text: "# 核心能力", t: "same" },
+    { ln: 5, text: "- 产品咨询：回答功能、价格", t: "same" },
+    { ln: 6, text: "- 投诉处理：记录并生成工单", t: "added" },
+    { ln: 7, text: "", t: "same" },
+    { ln: 8, text: "# 约束", t: "same" },
+    { ln: 9, text: "- 不确定时回复「让我查询」", t: "added" },
+    { ln: 10, text: "- 回复不超200字", t: "same" },
+    { ln: 11, text: "- 使用 Markdown 格式", t: "added" },
+  ],
+  flags: [
+    { desc: "投诉→转人工 改为 生成工单", sev: "high", impact: "流程变化" },
+    { desc: "不确定措辞变更", sev: "low", impact: "语义等价" },
+    { desc: "新增 Markdown 要求", sev: "medium", impact: "格式变化" },
+  ],
+};
+
+export const VARIABLE_MAPPINGS: VariableMapping[] = [
+  { coze: "{{input}}", dify: "{{#sys.query#}}", status: "mapped", auto: true },
+  { coze: "{{bot_id}}", dify: "{{#sys.app_id#}}", status: "mapped", auto: true },
+  { coze: "{{user_id}}", dify: "{{#sys.user_id#}}", status: "mapped", auto: true },
+  {
+    coze: "{{knowledge_result}}",
+    dify: "{{#knowledge.result#}}",
+    status: "mapped",
+    auto: false,
+  },
+  { coze: "{{plugin.weather}}", dify: "—", status: "unmapped", auto: false },
+  { coze: "{{user_level}}", dify: "—", status: "unmapped", auto: false },
+];
+
+export const PLUGIN_COMPATIBILITY: PluginCompatibilityItem[] = [
+  { coze: "天气查询", dify: "Weather Tool", compat: "full" },
+  { coze: "网页搜索", dify: "SerpAPI Tool", compat: "full" },
+  { coze: "图片生成", dify: "DALL-E Tool", compat: "partial" },
+  { coze: "数据库查询", dify: "自定义 Tool", compat: "custom" },
+  { coze: "日程管理", dify: "—", compat: "none" },
+];
+
+export const TEST_CASES: TestCase[] = [
+  {
+    id: "t1",
+    name: "基础问答",
+    input: "产品支持什么OS？",
+    cOut: "Win/Mac/Linux…",
+    dOut: "Win/Mac/Linux…",
+    sim: 0.96,
+    status: "pass",
+    cL: 1200,
+    dL: 980,
+  },
+  {
+    id: "t2",
+    name: "投诉处理",
+    input: "订单没发货不满意",
+    cOut: "非常抱歉…",
+    dOut: "非常抱歉…",
+    sim: 0.93,
+    status: "pass",
+    cL: 1500,
+    dL: 1100,
+  },
+  {
+    id: "t3",
+    name: "多轮上下文",
+    input: "查订单→物流？",
+    cOut: "ORD-2024…",
+    dOut: "请提供订单号？",
+    sim: 0.42,
+    status: "fail",
+    cL: 2100,
+    dL: 1800,
+    ep: "context_loss",
+  },
+  {
+    id: "t4",
+    name: "知识库召回",
+    input: "退货政策？",
+    cOut: "30天可退…",
+    dOut: "30天可退…",
+    sim: 0.91,
+    status: "pass",
+    cL: 1800,
+    dL: 1400,
+  },
+  {
+    id: "t5",
+    name: "超长输入",
+    input: "[2000字]",
+    cOut: "理解…",
+    dOut: "[ERROR]",
+    sim: 0,
+    status: "fail",
+    cL: 3200,
+    dL: 0,
+    ep: "api_format",
+  },
+  {
+    id: "t6",
+    name: "Session过期",
+    input: "[10轮后]方案？",
+    cOut: "方案A…",
+    dOut: "哪个？",
+    sim: 0.38,
+    status: "fail",
+    cL: 2500,
+    dL: 2200,
+    ep: "context_loss",
+  },
+];
+
+export const ERROR_PATTERNS: ErrorPattern[] = [
+  {
+    id: "ep1",
+    name: "上下文丢失",
+    key: "context_loss",
+    count: 2,
+    sev: "critical",
+    desc: "Dify 多轮对话丢失上下文",
+    fix: "检查 conversation_variables 和 memory 窗口",
+    tests: ["t3", "t6"],
+  },
+  {
+    id: "ep2",
+    name: "API格式不兼容",
+    key: "api_format",
+    count: 1,
+    sev: "high",
+    desc: "超长输入处理不同",
+    fix: "增加输入长度校验",
+    tests: ["t5"],
+  },
+];
+
+export const KNOWLEDGE_BASES: KnowledgeBaseRecord[] = [
+  { name: "产品FAQ", cC: 156, dC: 162, match: 0.91, emb: "一致", ok: true },
+  { name: "操作手册", cC: 89, dC: 89, match: 0.95, emb: "一致", ok: true },
+  { name: "故障排除", cC: 234, dC: 198, match: 0.72, emb: "不一致", ok: false },
+  { name: "定价文档", cC: 45, dC: 45, match: 0.98, emb: "一致", ok: true },
+];
+
+export const CANARY_STAGES: CanaryStage[] = [
+  { pct: 0, label: "准备", st: "done", ts: "03/10" },
+  { pct: 5, label: "5%", st: "done", ts: "03/10" },
+  { pct: 20, label: "20%", st: "active", ts: "03/11" },
+  { pct: 50, label: "50%", st: "pending", ts: "—" },
+  { pct: 100, label: "100%", st: "pending", ts: "—" },
+];
+
+export const ROLLBACK_VERSIONS: RollbackVersion[] = [
+  { ver: "v1.0", ts: "03-08", st: "archived", score: 78.2 },
+  { ver: "v1.2", ts: "03-10", st: "rollback", score: 91.7 },
+  { ver: "v1.3", ts: "03-11", st: "active", score: 93.4 },
+];
+
+export const REVIEW_QUEUE: ReviewItem[] = [
+  {
+    id: "r1",
+    testId: "t6",
+    q: "Session过期",
+    sim: 0.38,
+    cS: "方案A…",
+    dS: "哪个方案？",
+    verdict: null,
+  },
+  {
+    id: "r2",
+    testId: "t2",
+    q: "投诉措辞差异",
+    sim: 0.93,
+    cS: "给您带来了不便",
+    dS: "给您带来不便",
+    verdict: "equivalent",
+  },
+  {
+    id: "r3",
+    testId: "t4",
+    q: "知识库召回",
+    sim: 0.91,
+    cS: "30天内可退换",
+    dS: "30天内可退",
+    verdict: null,
+  },
+];
+
+export const SANDBOX_METRICS: LiveMetric[] = [
+  { label: "请求数", coze: "142", dify: "142" },
+  { label: "平均延迟", coze: "1.2s", dify: "0.9s" },
+  { label: "错误率", coze: "0.7%", dify: "1.4%" },
+];

--- a/frontend/src/features/migrationWorkbench/theme.ts
+++ b/frontend/src/features/migrationWorkbench/theme.ts
@@ -1,0 +1,88 @@
+import type { StatusMeta, WorkbenchPageKey } from "./types";
+
+export const C = {
+  bg: "#060a12",
+  s1: "#0c1221",
+  s2: "#12192d",
+  s3: "#182240",
+  bd: "#1c2a48",
+  bdL: "#263a5a",
+  tx: "#dce4f0",
+  tx2: "#7889a6",
+  tx3: "#4d5f7a",
+  acc: "#00d4ff",
+  accD: "rgba(0,212,255,0.1)",
+  coze: "#4ea8ff",
+  cozeD: "rgba(78,168,255,0.1)",
+  dify: "#b27aff",
+  difyD: "rgba(178,122,255,0.1)",
+  ok: "#22dda0",
+  okD: "rgba(34,221,160,0.1)",
+  warn: "#ffaa3e",
+  warnD: "rgba(255,170,62,0.1)",
+  err: "#ff5264",
+  errD: "rgba(255,82,100,0.1)",
+  ft: "'JetBrains Mono','Noto Sans SC',system-ui,sans-serif",
+  mono: "'JetBrains Mono','Fira Code',monospace",
+} as const;
+
+export const STATUS_MAP: Record<
+  "verified" | "migrated" | "testing" | "pending" | "failed",
+  StatusMeta & { color: string }
+> = {
+  verified: { label: "已验证", tone: "success", color: C.ok },
+  migrated: { label: "已迁移", tone: "info", color: C.coze },
+  testing: { label: "测试中", tone: "warning", color: C.warn },
+  pending: { label: "待迁移", tone: "muted", color: C.tx2 },
+  failed: { label: "失败", tone: "danger", color: C.err },
+};
+
+export const COMPLEXITY_MAP = {
+  high: { label: "高", color: C.err, tone: "danger" as const },
+  medium: { label: "中", color: C.warn, tone: "warning" as const },
+  low: { label: "低", color: C.ok, tone: "success" as const },
+};
+
+export const NODE_LABELS = {
+  llm: "LLM",
+  knowledge: "KB",
+  code: "CODE",
+  condition: "IF",
+  http: "HTTP",
+  variable: "VAR",
+  start: "IN",
+  end: "OUT",
+} as const;
+
+export const NODE_ICONS = {
+  llm: "🧠",
+  knowledge: "📚",
+  code: "⚡",
+  condition: "🔀",
+  http: "🌐",
+  variable: "📦",
+  start: "▶",
+  end: "⏹",
+} as const;
+
+export const NODE_COLORS = {
+  llm: C.coze,
+  knowledge: C.ok,
+  code: C.warn,
+  condition: C.dify,
+  http: "#fb923c",
+  variable: "#f472b6",
+  start: C.tx2,
+  end: C.tx2,
+} as const;
+
+export const WORKBENCH_NAV: Array<{ key: WorkbenchPageKey; label: string; group: string }> = [
+  { key: "dashboard", label: "迁移概览", group: "总览" },
+  { key: "dag", label: "拓扑对比", group: "分析" },
+  { key: "equiv", label: "等价验证", group: "分析" },
+  { key: "test", label: "自动测试", group: "分析" },
+  { key: "canary", label: "灰度发布", group: "运维" },
+  { key: "kb", label: "知识库", group: "运维" },
+  { key: "review", label: "人工审核", group: "运维" },
+  { key: "sandbox", label: "沙箱环境", group: "工具" },
+];

--- a/frontend/src/features/migrationWorkbench/types.ts
+++ b/frontend/src/features/migrationWorkbench/types.ts
@@ -1,0 +1,193 @@
+export type Tone = "accent" | "info" | "success" | "warning" | "danger" | "muted";
+
+export type WorkflowStatus =
+  | "verified"
+  | "migrated"
+  | "testing"
+  | "pending"
+  | "failed";
+
+export type ComplexityLevel = "high" | "medium" | "low";
+
+export type DagNodeType =
+  | "llm"
+  | "knowledge"
+  | "code"
+  | "condition"
+  | "http"
+  | "variable"
+  | "start"
+  | "end";
+
+export type NodeComparisonStatus = "equivalent" | "warning" | "error";
+export type Severity = "critical" | "high" | "medium" | "low";
+export type Compatibility = "full" | "partial" | "custom" | "none";
+export type TestStatus = "pass" | "fail";
+export type ReviewVerdict = "equivalent" | "acceptable" | "not_eq" | null;
+export type SandboxStatus = "idle" | "starting" | "running";
+
+export type WorkbenchPageKey =
+  | "dashboard"
+  | "dag"
+  | "equiv"
+  | "test"
+  | "canary"
+  | "kb"
+  | "review"
+  | "sandbox";
+
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  cozeId: string;
+  difyId: string | null;
+  status: WorkflowStatus;
+  nodes: number;
+  migrated: number;
+  failed: number;
+  score: number;
+  complexity: ComplexityLevel;
+  lastSync: string | null;
+}
+
+export interface StatusMeta {
+  label: string;
+  tone: Tone;
+}
+
+export interface DagNode {
+  id: string;
+  type: DagNodeType;
+  label: string;
+  x: number;
+  y: number;
+}
+
+export interface DagGraphData {
+  nodes: DagNode[];
+  edges: Array<[string, string]>;
+}
+
+export interface NodeConfigDiff {
+  field: string;
+  coze: string;
+  dify: string;
+  sev: Exclude<Severity, "critical">;
+}
+
+export interface NodeComparison {
+  id: string;
+  type: DagNodeType;
+  name: string;
+  cCfg: Record<string, string | number | boolean>;
+  dCfg: Record<string, string | number | boolean>;
+  status: NodeComparisonStatus;
+  diff: NodeConfigDiff[];
+}
+
+export interface PromptLine {
+  ln: number;
+  text: string;
+  t: "same" | "removed" | "added";
+}
+
+export interface PromptFlag {
+  desc: string;
+  sev: Exclude<Severity, "critical">;
+  impact: string;
+}
+
+export interface PromptDiffData {
+  coze: PromptLine[];
+  dify: PromptLine[];
+  flags: PromptFlag[];
+}
+
+export interface VariableMapping {
+  coze: string;
+  dify: string;
+  status: "mapped" | "unmapped";
+  auto: boolean;
+}
+
+export interface PluginCompatibilityItem {
+  coze: string;
+  dify: string;
+  compat: Compatibility;
+}
+
+export interface TestCase {
+  id: string;
+  name: string;
+  input: string;
+  cOut: string;
+  dOut: string;
+  sim: number;
+  status: TestStatus;
+  cL: number;
+  dL: number;
+  ep?: string;
+}
+
+export interface ErrorPattern {
+  id: string;
+  name: string;
+  key: string;
+  count: number;
+  sev: "critical" | "high";
+  desc: string;
+  fix: string;
+  tests: string[];
+}
+
+export interface KnowledgeBaseRecord {
+  name: string;
+  cC: number;
+  dC: number;
+  match: number;
+  emb: string;
+  ok: boolean;
+}
+
+export interface CanaryStage {
+  pct: number;
+  label: string;
+  st: "done" | "active" | "pending";
+  ts: string;
+}
+
+export interface RollbackVersion {
+  ver: string;
+  ts: string;
+  st: "archived" | "rollback" | "active";
+  score: number;
+}
+
+export interface ReviewItem {
+  id: string;
+  testId: string;
+  q: string;
+  sim: number;
+  cS: string;
+  dS: string;
+  verdict: ReviewVerdict;
+}
+
+export interface StructureDiffItem {
+  text: string;
+  sev: Exclude<Severity, "critical">;
+}
+
+export interface SandboxMessage {
+  id: string;
+  role: "user" | "coze" | "dify";
+  text: string;
+  latencyMs?: number;
+}
+
+export interface LiveMetric {
+  label: string;
+  coze: string;
+  dify: string;
+}
+

--- a/frontend/src/features/migrationWorkbench/utils.ts
+++ b/frontend/src/features/migrationWorkbench/utils.ts
@@ -1,0 +1,75 @@
+import type { ReviewItem, Severity, Tone, WorkflowSummary } from "./types";
+
+export function summarizeWorkflows(workflows: WorkflowSummary[], reviewQueue: ReviewItem[]) {
+  const scored = workflows.filter((workflow) => workflow.score > 0);
+  const averageScore =
+    scored.reduce((total, workflow) => total + workflow.score, 0) /
+    (scored.length || 1);
+  const totalNodes = workflows.reduce((total, workflow) => total + workflow.nodes, 0);
+  const migratedNodes = workflows.reduce(
+    (total, workflow) => total + workflow.migrated,
+    0,
+  );
+  const failedNodes = workflows.reduce((total, workflow) => total + workflow.failed, 0);
+
+  return {
+    totalWorkflows: workflows.length,
+    verifiedWorkflows: workflows.filter((workflow) => workflow.status === "verified").length,
+    averageScore,
+    totalNodes,
+    migratedNodes,
+    failedNodes,
+    pendingReviews: reviewQueue.filter((item) => !item.verdict).length,
+  };
+}
+
+export function progressPercent(value: number, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, (value / total) * 100));
+}
+
+export function getSimilarityTone(similarity: number): Tone {
+  if (similarity >= 0.85) {
+    return "success";
+  }
+  if (similarity >= 0.5) {
+    return "warning";
+  }
+
+  return "danger";
+}
+
+export function getSeverityTone(severity: Severity): Tone {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "danger";
+    case "medium":
+      return "warning";
+    case "low":
+      return "accent";
+    default:
+      return "muted";
+  }
+}
+
+export function buildSandboxReply(text: string, platform: "coze" | "dify") {
+  const prefix = platform === "coze" ? "[Coze]" : "[Dify]";
+  const latencyMs =
+    platform === "coze"
+      ? Math.floor(800 + Math.random() * 1200)
+      : Math.floor(600 + Math.random() * 1000);
+
+  return {
+    role: platform,
+    text: `${prefix} ${text.slice(0, 15)}${text.length > 15 ? "…" : ""}`,
+    latencyMs,
+  } as const;
+}
+
+export function createMessageId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/frontend/src/features/migrationWorkbench/views/EquivalenceView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/EquivalenceView.tsx
@@ -1,0 +1,461 @@
+import { useState } from "react";
+import { C } from "../theme";
+import {
+  NODE_COMPARISONS,
+  PLUGIN_COMPATIBILITY,
+  PROMPT_DIFF,
+  VARIABLE_MAPPINGS,
+} from "../mockData";
+import type { WorkflowSummary } from "../types";
+import { getSeverityTone } from "../utils";
+import Panel from "../components/Panel";
+import SectionHeader from "../components/SectionHeader";
+import SegmentTabs from "../components/SegmentTabs";
+import StatusBadge from "../components/StatusBadge";
+import { IcArrow, IcCheck, IcWarn, IcX } from "../components/icons";
+
+type EquivalenceTab = "nodes" | "prompt" | "vars" | "plugins";
+
+interface EquivalenceViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function EquivalenceView({ workflow }: EquivalenceViewProps) {
+  const [tab, setTab] = useState<EquivalenceTab>("nodes");
+  const [selectedId, setSelectedId] = useState(NODE_COMPARISONS[0]?.id ?? "");
+  const selectedNode =
+    NODE_COMPARISONS.find((node) => node.id === selectedId) ?? NODE_COMPARISONS[0];
+
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>等价验证</h1>
+      <p style={{ margin: "0 0 14px", color: C.tx2, fontSize: 12 }}>{workflow.name}</p>
+
+      <SegmentTabs
+        activeKey={tab}
+        items={[
+          { key: "nodes", label: "节点对比", icon: <span>🔀</span> },
+          { key: "prompt", label: "Prompt Diff", icon: <span>📝</span> },
+          { key: "vars", label: "变量映射", icon: <span>📦</span> },
+          { key: "plugins", label: "插件矩阵", icon: <span>🔌</span> },
+        ]}
+        onChange={setTab}
+      />
+
+      <div style={{ marginTop: 12 }}>
+        {tab === "nodes" && (
+          <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 12 }}>
+            <Panel style={{ padding: 6 }}>
+              {NODE_COMPARISONS.map((node) => {
+                const color =
+                  node.status === "equivalent"
+                    ? C.ok
+                    : node.status === "warning"
+                      ? C.warn
+                      : C.err;
+
+                return (
+                  <div
+                    key={node.id}
+                    onClick={() => setSelectedId(node.id)}
+                    style={{
+                      padding: "8px 10px",
+                      borderRadius: 4,
+                      cursor: "pointer",
+                      marginBottom: 1,
+                      background: selectedNode?.id === node.id ? `${color}12` : "transparent",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <span style={{ fontSize: 14 }}>
+                        {node.type === "llm"
+                          ? "🧠"
+                          : node.type === "knowledge"
+                            ? "📚"
+                            : node.type === "code"
+                              ? "⚡"
+                              : node.type === "http"
+                                ? "🌐"
+                                : node.type === "condition"
+                                  ? "🔀"
+                                  : "📦"}
+                      </span>
+                      <div style={{ flex: 1 }}>
+                        <div style={{ fontSize: 12, fontWeight: 500 }}>{node.name}</div>
+                      </div>
+                      <span style={{ color }}>
+                        {node.status === "equivalent" ? (
+                          <IcCheck />
+                        ) : node.status === "warning" ? (
+                          <IcWarn />
+                        ) : (
+                          <IcX />
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </Panel>
+
+            <Panel style={{ padding: "16px 18px" }}>
+              {selectedNode ? (
+                <div>
+                  <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 12 }}>
+                    {selectedNode.type === "llm"
+                      ? "🧠"
+                      : selectedNode.type === "knowledge"
+                        ? "📚"
+                        : selectedNode.type === "code"
+                          ? "⚡"
+                          : selectedNode.type === "http"
+                            ? "🌐"
+                            : selectedNode.type === "condition"
+                              ? "🔀"
+                              : "📦"}{" "}
+                    {selectedNode.name}
+                  </div>
+
+                  {selectedNode.diff.map((diff) => (
+                    <div
+                      key={diff.field}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 5,
+                        marginBottom: 8,
+                        fontSize: 11,
+                        background: diff.sev === "high" ? C.errD : C.warnD,
+                      }}
+                    >
+                      <StatusBadge tone={getSeverityTone(diff.sev)}>
+                        {diff.sev.toUpperCase()}
+                      </StatusBadge>{" "}
+                      {diff.field}: <span style={{ color: C.err }}>- {diff.coze}</span>{" "}
+                      <span style={{ color: C.ok }}>+ {diff.dify}</span>
+                    </div>
+                  ))}
+
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr",
+                      gap: 10,
+                    }}
+                  >
+                    {[
+                      { label: "Coze", cfg: selectedNode.cCfg, color: C.coze },
+                      { label: "Dify", cfg: selectedNode.dCfg, color: C.dify },
+                    ].map((side) => (
+                      <div key={side.label}>
+                        <div
+                          style={{
+                            fontSize: 10,
+                            fontWeight: 700,
+                            color: side.color,
+                            marginBottom: 5,
+                            textTransform: "uppercase",
+                          }}
+                        >
+                          {side.label}
+                        </div>
+                        <pre
+                          style={{
+                            padding: 12,
+                            borderRadius: 6,
+                            background: "rgba(0,0,0,0.3)",
+                            fontSize: 11,
+                            fontFamily: C.mono,
+                            lineHeight: 1.6,
+                            margin: 0,
+                            color: `${side.color}cc`,
+                          }}
+                        >
+                          {JSON.stringify(side.cfg, null, 2)}
+                        </pre>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div
+                  style={{
+                    height: 200,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: C.tx3,
+                  }}
+                >
+                  ← 选择节点
+                </div>
+              )}
+            </Panel>
+          </div>
+        )}
+
+        {tab === "prompt" && (
+          <Panel style={{ padding: 0, overflow: "hidden" }}>
+            <div
+              style={{
+                display: "flex",
+                gap: 12,
+                padding: "12px 16px",
+                borderBottom: `1px solid ${C.bd}`,
+              }}
+            >
+              <StatusBadge tone="warning">{PROMPT_DIFF.flags.length} 变更</StatusBadge>
+              <StatusBadge tone="success">相似度 88%</StatusBadge>
+            </div>
+
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr" }}>
+              {[
+                { label: "Coze", lines: PROMPT_DIFF.coze, color: C.coze },
+                { label: "Dify", lines: PROMPT_DIFF.dify, color: C.dify },
+              ].map((side) => (
+                <div
+                  key={side.label}
+                  style={{
+                    borderRight: side.label === "Coze" ? `1px solid ${C.bd}` : "none",
+                  }}
+                >
+                  <div
+                    style={{
+                      padding: "8px 14px",
+                      background: C.s2,
+                      borderBottom: `1px solid ${C.bd}`,
+                      fontSize: 10,
+                      fontWeight: 700,
+                      color: side.color,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {side.label} System Prompt
+                  </div>
+                  {side.lines.map((line) => (
+                    <div
+                      key={`${side.label}-${line.ln}`}
+                      style={{
+                        display: "flex",
+                        fontSize: 11,
+                        fontFamily: C.mono,
+                        lineHeight: "22px",
+                        background:
+                          line.t === "removed"
+                            ? "rgba(255,82,100,0.06)"
+                            : line.t === "added"
+                              ? "rgba(34,221,160,0.06)"
+                              : "transparent",
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 24,
+                          textAlign: "right",
+                          paddingRight: 6,
+                          color: C.tx3,
+                          opacity: 0.4,
+                          fontSize: 9,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {line.ln}
+                      </span>
+                      <span
+                        style={{
+                          color:
+                            line.t === "removed"
+                              ? C.err
+                              : line.t === "added"
+                                ? C.ok
+                                : C.tx,
+                        }}
+                      >
+                        {line.t === "removed" ? "- " : line.t === "added" ? "+ " : "  "}
+                        {line.text || " "}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+
+            <div style={{ padding: "14px 16px", borderTop: `1px solid ${C.bd}` }}>
+              <SectionHeader>AI 标记的关键变更</SectionHeader>
+              {PROMPT_DIFF.flags.map((flag) => {
+                const tone = getSeverityTone(flag.sev);
+                const background =
+                  tone === "danger" ? C.errD : tone === "warning" ? C.warnD : C.accD;
+
+                return (
+                  <div
+                    key={flag.desc}
+                    style={{
+                      padding: "8px 12px",
+                      borderRadius: 5,
+                      marginBottom: 5,
+                      background,
+                    }}
+                  >
+                    <StatusBadge tone={tone}>
+                      {flag.sev === "high"
+                        ? "高风险"
+                        : flag.sev === "medium"
+                          ? "中风险"
+                          : "低风险"}
+                    </StatusBadge>
+                    <span style={{ fontSize: 12, marginLeft: 6 }}>{flag.desc}</span>
+                    <div style={{ fontSize: 10, color: C.tx3, marginTop: 2 }}>
+                      影响: {flag.impact}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </Panel>
+        )}
+
+        {tab === "vars" && (
+          <Panel style={{ padding: "16px 18px" }}>
+            <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+              <StatusBadge tone="success">
+                已映射 {VARIABLE_MAPPINGS.filter((item) => item.status === "mapped").length}
+              </StatusBadge>
+              <StatusBadge tone="danger">
+                未映射 {VARIABLE_MAPPINGS.filter((item) => item.status === "unmapped").length}
+              </StatusBadge>
+            </div>
+
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ borderBottom: `1px solid ${C.bd}` }}>
+                  {["Coze", "", "Dify", "方式", "状态"].map((header) => (
+                    <th
+                      key={header}
+                      style={{
+                        padding: "7px 10px",
+                        fontSize: 9,
+                        fontWeight: 700,
+                        color: C.tx3,
+                        textAlign: "left",
+                      }}
+                    >
+                      {header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {VARIABLE_MAPPINGS.map((mapping, index) => (
+                  <tr key={`${mapping.coze}-${index}`} style={{ borderBottom: `1px solid ${C.bd}` }}>
+                    <td
+                      style={{
+                        padding: "8px 10px",
+                        fontFamily: C.mono,
+                        fontSize: 11,
+                        color: C.coze,
+                      }}
+                    >
+                      {mapping.coze}
+                    </td>
+                    <td style={{ padding: "8px 4px", color: C.tx3 }}>
+                      <IcArrow />
+                    </td>
+                    <td
+                      style={{
+                        padding: "8px 10px",
+                        fontFamily: C.mono,
+                        fontSize: 11,
+                        color: mapping.status === "mapped" ? C.dify : C.err,
+                      }}
+                    >
+                      {mapping.dify}
+                    </td>
+                    <td style={{ padding: "8px 10px" }}>
+                      <StatusBadge tone={mapping.auto ? "success" : "warning"}>
+                        {mapping.auto ? "自动" : "手动"}
+                      </StatusBadge>
+                    </td>
+                    <td style={{ padding: "8px 10px" }}>
+                      {mapping.status === "mapped" ? (
+                        <span style={{ color: C.ok }}>
+                          <IcCheck />
+                        </span>
+                      ) : (
+                        <StatusBadge tone="danger">未映射</StatusBadge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Panel>
+        )}
+
+        {tab === "plugins" && (
+          <Panel style={{ padding: "16px 18px" }}>
+            <SectionHeader>Plugin → Tool 兼容矩阵</SectionHeader>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ borderBottom: `1px solid ${C.bd}` }}>
+                  {["Coze 插件", "Dify Tool", "兼容性"].map((header) => (
+                    <th
+                      key={header}
+                      style={{
+                        padding: "7px 10px",
+                        fontSize: 9,
+                        fontWeight: 700,
+                        color: C.tx3,
+                        textAlign: "left",
+                      }}
+                    >
+                      {header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {PLUGIN_COMPATIBILITY.map((plugin, index) => {
+                  const tone =
+                    plugin.compat === "full"
+                      ? "success"
+                      : plugin.compat === "partial"
+                        ? "warning"
+                        : plugin.compat === "custom"
+                          ? "accent"
+                          : "danger";
+                  const label =
+                    plugin.compat === "full"
+                      ? "完全"
+                      : plugin.compat === "partial"
+                        ? "部分"
+                        : plugin.compat === "custom"
+                          ? "自建"
+                          : "不支持";
+
+                  return (
+                    <tr key={`${plugin.coze}-${index}`} style={{ borderBottom: `1px solid ${C.bd}` }}>
+                      <td style={{ padding: "8px 10px", fontSize: 12 }}>{plugin.coze}</td>
+                      <td
+                        style={{
+                          padding: "8px 10px",
+                          fontSize: 11,
+                          fontFamily: C.mono,
+                          color: plugin.compat === "none" ? C.err : C.dify,
+                        }}
+                      >
+                        {plugin.dify}
+                      </td>
+                      <td style={{ padding: "8px 10px" }}>
+                        <StatusBadge tone={tone}>{label}</StatusBadge>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </Panel>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/KnowledgeView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/KnowledgeView.tsx
@@ -1,0 +1,104 @@
+import { C } from "../theme";
+import { KNOWLEDGE_BASES } from "../mockData";
+import type { WorkflowSummary } from "../types";
+import Panel from "../components/Panel";
+import { IcCheck } from "../components/icons";
+import StatusBadge from "../components/StatusBadge";
+
+interface KnowledgeViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function KnowledgeView({ workflow }: KnowledgeViewProps) {
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>知识库迁移</h1>
+      <p style={{ margin: "0 0 18px", color: C.tx2, fontSize: 12 }}>
+        {workflow.name} · 分片 / 召回一致性
+      </p>
+
+      <Panel style={{ padding: "16px 18px" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ borderBottom: `1px solid ${C.bd}` }}>
+              {["知识库", "Coze分片", "Dify分片", "召回率", "Embedding", "状态"].map((header) => (
+                <th
+                  key={header}
+                  style={{
+                    padding: "7px 10px",
+                    fontSize: 9,
+                    fontWeight: 700,
+                    color: C.tx3,
+                    textAlign: "left",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {KNOWLEDGE_BASES.map((record, index) => (
+              <tr key={`${record.name}-${index}`} style={{ borderBottom: `1px solid ${C.bd}` }}>
+                <td style={{ padding: "8px 10px", fontWeight: 500, fontSize: 12 }}>
+                  {record.name}
+                </td>
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    fontFamily: C.mono,
+                    fontSize: 11,
+                    color: C.coze,
+                  }}
+                >
+                  {record.cC}
+                </td>
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    fontFamily: C.mono,
+                    fontSize: 11,
+                    color: C.dify,
+                  }}
+                >
+                  {record.dC}
+                </td>
+                <td style={{ padding: "8px 10px" }}>
+                  <span
+                    style={{
+                      fontFamily: C.mono,
+                      fontWeight: 700,
+                      color:
+                        record.match >= 0.9 ? C.ok : record.match >= 0.8 ? C.warn : C.err,
+                    }}
+                  >
+                    {(record.match * 100).toFixed(0)}%
+                  </span>
+                </td>
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    fontSize: 10,
+                    color: record.emb === "不一致" ? C.err : C.tx2,
+                  }}
+                >
+                  {record.emb}
+                </td>
+                <td style={{ padding: "8px 10px" }}>
+                  {record.ok ? (
+                    <span style={{ color: C.ok }}>
+                      <IcCheck />
+                    </span>
+                  ) : (
+                    <StatusBadge tone="danger">异常</StatusBadge>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Panel>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/OverviewView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/OverviewView.tsx
@@ -1,0 +1,247 @@
+import { COMPLEXITY_MAP, C, STATUS_MAP } from "../theme";
+import type { ReviewItem, WorkflowSummary } from "../types";
+import { summarizeWorkflows } from "../utils";
+import Panel from "../components/Panel";
+import ProgressBar from "../components/ProgressBar";
+import SectionHeader from "../components/SectionHeader";
+import StatusBadge from "../components/StatusBadge";
+import WorkbenchButton from "../components/WorkbenchButton";
+import { IcArrow } from "../components/icons";
+
+interface OverviewViewProps {
+  workflows: WorkflowSummary[];
+  reviewQueue: ReviewItem[];
+  onInspectWorkflow: (workflowId: string) => void;
+}
+
+export default function OverviewView({
+  workflows,
+  reviewQueue,
+  onInspectWorkflow,
+}: OverviewViewProps) {
+  const summary = summarizeWorkflows(workflows, reviewQueue);
+  const cards = [
+    {
+      label: "总工作流",
+      value: summary.totalWorkflows,
+      sub: `${summary.verifiedWorkflows} 已验证`,
+      color: C.acc,
+    },
+    {
+      label: "平均等价分",
+      value: summary.averageScore.toFixed(1),
+      sub: "目标≥95",
+      color: summary.averageScore >= 95 ? C.ok : C.warn,
+    },
+    {
+      label: "节点迁移率",
+      value: `${((summary.migratedNodes / summary.totalNodes) * 100 || 0).toFixed(1)}%`,
+      sub: `${summary.migratedNodes}/${summary.totalNodes}`,
+      color: C.ok,
+    },
+    {
+      label: "失败节点",
+      value: summary.failedNodes,
+      sub: "需人工",
+      color: summary.failedNodes > 0 ? C.err : C.ok,
+    },
+    {
+      label: "待审用例",
+      value: summary.pendingReviews,
+      sub: "人工审核",
+      color: C.warn,
+    },
+  ];
+
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>迁移概览</h1>
+      <p style={{ margin: "0 0 20px", color: C.tx2, fontSize: 12 }}>
+        Coze → Dify 全局状态
+      </p>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(5,1fr)",
+          gap: 10,
+          marginBottom: 20,
+        }}
+      >
+        {cards.map((card) => (
+          <Panel key={card.label} style={{ padding: "14px 16px" }}>
+            <div
+              style={{
+                fontSize: 10,
+                color: C.tx3,
+                textTransform: "uppercase",
+                letterSpacing: ".05em",
+                marginBottom: 6,
+              }}
+            >
+              {card.label}
+            </div>
+            <div
+              style={{
+                fontSize: 24,
+                fontWeight: 700,
+                fontFamily: C.mono,
+                color: card.color,
+                lineHeight: 1,
+              }}
+            >
+              {card.value}
+            </div>
+            <div style={{ fontSize: 10, color: C.tx3, marginTop: 4 }}>{card.sub}</div>
+          </Panel>
+        ))}
+      </div>
+
+      <Panel style={{ padding: "16px 18px", marginBottom: 20 }}>
+        <SectionHeader>迁移进度</SectionHeader>
+        {Object.entries(STATUS_MAP).map(([key, status]) => {
+          const count = workflows.filter((workflow) => workflow.status === key).length;
+
+          return (
+            <div
+              key={key}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginBottom: 7,
+              }}
+            >
+              <span
+                style={{
+                  width: 52,
+                  fontSize: 11,
+                  color: status.color,
+                  fontWeight: 500,
+                }}
+              >
+                {status.label}
+              </span>
+              <div style={{ flex: 1 }}>
+                <ProgressBar value={count} total={workflows.length} tone={status.tone} />
+              </div>
+              <span
+                style={{
+                  width: 16,
+                  fontSize: 10,
+                  fontFamily: C.mono,
+                  color: C.tx2,
+                  textAlign: "right",
+                }}
+              >
+                {count}
+              </span>
+            </div>
+          );
+        })}
+      </Panel>
+
+      <SectionHeader
+        action={
+          <WorkbenchButton compact variant="primary" type="button">
+            <IcArrow />
+            批量迁移
+          </WorkbenchButton>
+        }
+      >
+        工作流列表
+      </SectionHeader>
+
+      <Panel>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ borderBottom: `1px solid ${C.bd}` }}>
+              {["工作流", "状态", "节点", "等价分", "复杂度", ""].map((header) => (
+                <th
+                  key={header}
+                  style={{
+                    padding: "8px 12px",
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color: C.tx3,
+                    textAlign: "left",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {workflows.map((workflow) => {
+              const status = STATUS_MAP[workflow.status];
+              const complexity = COMPLEXITY_MAP[workflow.complexity];
+
+              return (
+                <tr
+                  key={workflow.id}
+                  onClick={() => onInspectWorkflow(workflow.id)}
+                  style={{
+                    borderBottom: `1px solid ${C.bd}`,
+                    cursor: "pointer",
+                  }}
+                >
+                  <td style={{ padding: "10px 12px" }}>
+                    <div style={{ fontWeight: 600, fontSize: 12 }}>{workflow.name}</div>
+                    <div style={{ fontSize: 10, color: C.tx3, fontFamily: C.mono }}>
+                      {workflow.cozeId}
+                    </div>
+                  </td>
+                  <td style={{ padding: "10px 12px" }}>
+                    <StatusBadge tone={status.tone}>{status.label}</StatusBadge>
+                  </td>
+                  <td style={{ padding: "10px 12px" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <ProgressBar
+                        value={workflow.migrated}
+                        total={workflow.nodes}
+                        tone={workflow.failed > 0 ? "warning" : "success"}
+                      />
+                      <span style={{ fontSize: 10, fontFamily: C.mono, color: C.tx2 }}>
+                        {workflow.migrated}/{workflow.nodes}
+                      </span>
+                    </div>
+                  </td>
+                  <td style={{ padding: "10px 12px" }}>
+                    {workflow.score > 0 ? (
+                      <span
+                        style={{
+                          fontFamily: C.mono,
+                          fontWeight: 700,
+                          color:
+                            workflow.score >= 90
+                              ? C.ok
+                              : workflow.score >= 70
+                                ? C.warn
+                                : C.err,
+                        }}
+                      >
+                        {workflow.score.toFixed(1)}
+                      </span>
+                    ) : (
+                      <span style={{ color: C.tx3 }}>—</span>
+                    )}
+                  </td>
+                  <td style={{ padding: "10px 12px" }}>
+                    <StatusBadge tone={complexity.tone}>{complexity.label}</StatusBadge>
+                  </td>
+                  <td style={{ padding: "10px 12px" }}>
+                    <WorkbenchButton compact variant="primary" type="button">
+                      详情
+                    </WorkbenchButton>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Panel>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/ReleaseView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/ReleaseView.tsx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+import { C } from "../theme";
+import { CANARY_STAGES, ROLLBACK_VERSIONS } from "../mockData";
+import type { WorkflowSummary } from "../types";
+import Panel from "../components/Panel";
+import SectionHeader from "../components/SectionHeader";
+import StatusBadge from "../components/StatusBadge";
+import WorkbenchButton from "../components/WorkbenchButton";
+
+interface ReleaseViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function ReleaseView({ workflow }: ReleaseViewProps) {
+  const [traffic, setTraffic] = useState(20);
+  const activeIndex = CANARY_STAGES.findIndex((stage) => stage.st === "active");
+
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>灰度发布</h1>
+      <p style={{ margin: "0 0 18px", color: C.tx2, fontSize: 12 }}>
+        {workflow.name} · 流量切换 / 回滚
+      </p>
+
+      <Panel style={{ padding: "18px 20px", marginBottom: 16 }}>
+        <SectionHeader>发布阶段</SectionHeader>
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {CANARY_STAGES.map((stage, index) => (
+            <div
+              key={stage.label}
+              style={{ display: "contents" }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <div
+                  style={{
+                    width: 30,
+                    height: 30,
+                    borderRadius: "50%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 10,
+                    fontWeight: 700,
+                    fontFamily: C.mono,
+                    background:
+                      stage.st === "done" ? C.ok : stage.st === "active" ? C.acc : C.bd,
+                    color: stage.st !== "pending" ? "#fff" : C.tx3,
+                  }}
+                >
+                  {stage.pct}%
+                </div>
+                <div
+                  style={{
+                    fontSize: 10,
+                    fontWeight: stage.st === "active" ? 700 : 400,
+                    color:
+                      stage.st === "active"
+                        ? C.acc
+                        : stage.st === "done"
+                          ? C.ok
+                          : C.tx3,
+                  }}
+                >
+                  {stage.label}
+                </div>
+              </div>
+              {index < CANARY_STAGES.length - 1 && (
+                <div
+                  style={{
+                    flex: 1,
+                    height: 2,
+                    background: index < activeIndex ? C.ok : C.bd,
+                    margin: "0 4px",
+                    marginBottom: 20,
+                  }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </Panel>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <Panel style={{ padding: "16px 18px" }}>
+          <SectionHeader>流量分配</SectionHeader>
+          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 5 }}>
+            <span style={{ fontSize: 11, color: C.coze, fontWeight: 600 }}>
+              Coze {100 - traffic}%
+            </span>
+            <span style={{ fontSize: 11, color: C.dify, fontWeight: 600 }}>
+              Dify {traffic}%
+            </span>
+          </div>
+          <div
+            style={{
+              height: 16,
+              background: C.bd,
+              borderRadius: 8,
+              overflow: "hidden",
+              marginBottom: 6,
+              display: "flex",
+            }}
+          >
+            <div
+              style={{
+                width: `${100 - traffic}%`,
+                background: C.coze,
+                transition: "width .3s",
+              }}
+            />
+            <div
+              style={{
+                width: `${traffic}%`,
+                background: C.dify,
+                transition: "width .3s",
+              }}
+            />
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={traffic}
+            onChange={(event) => setTraffic(Number(event.target.value))}
+            style={{ width: "100%", marginBottom: 8 }}
+          />
+          <div style={{ display: "flex", gap: 5 }}>
+            {[5, 20, 50, 100].map((preset) => (
+              <WorkbenchButton
+                key={preset}
+                compact
+                type="button"
+                variant={traffic === preset ? "primary" : "secondary"}
+                onClick={() => setTraffic(preset)}
+              >
+                {preset}%
+              </WorkbenchButton>
+            ))}
+            <WorkbenchButton
+              compact
+              type="button"
+              variant="danger"
+              style={{ marginLeft: "auto" }}
+            >
+              回滚
+            </WorkbenchButton>
+          </div>
+        </Panel>
+
+        <Panel style={{ padding: "16px 18px" }}>
+          <SectionHeader>版本历史</SectionHeader>
+          {ROLLBACK_VERSIONS.map((version, index) => (
+            <div
+              key={version.ver}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 0",
+                borderBottom: index < ROLLBACK_VERSIONS.length - 1 ? `1px solid ${C.bd}` : "none",
+              }}
+            >
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background:
+                    version.st === "active"
+                      ? C.ok
+                      : version.st === "rollback"
+                        ? C.warn
+                        : C.tx3,
+                }}
+              />
+              <div style={{ flex: 1 }}>
+                <span style={{ fontSize: 12, fontWeight: 600, fontFamily: C.mono }}>
+                  {version.ver}
+                </span>{" "}
+                <StatusBadge
+                  tone={
+                    version.st === "active"
+                      ? "success"
+                      : version.st === "rollback"
+                        ? "warning"
+                        : "muted"
+                  }
+                >
+                  {version.st === "active"
+                    ? "当前"
+                    : version.st === "rollback"
+                      ? "可回滚"
+                      : "归档"}
+                </StatusBadge>
+                <div style={{ fontSize: 9, color: C.tx3 }}>
+                  {version.ts} · 等价分:{" "}
+                  <span
+                    style={{
+                      color: version.score >= 90 ? C.ok : C.warn,
+                      fontFamily: C.mono,
+                    }}
+                  >
+                    {version.score}
+                  </span>
+                </div>
+              </div>
+              {version.st === "rollback" && (
+                <WorkbenchButton compact type="button" variant="danger">
+                  回滚
+                </WorkbenchButton>
+              )}
+            </div>
+          ))}
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/ReviewView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/ReviewView.tsx
@@ -1,0 +1,140 @@
+import type { Dispatch, SetStateAction } from "react";
+import { C } from "../theme";
+import type { ReviewItem, WorkflowSummary } from "../types";
+import Panel from "../components/Panel";
+import StatusBadge from "../components/StatusBadge";
+import WorkbenchButton from "../components/WorkbenchButton";
+
+interface ReviewViewProps {
+  workflow: WorkflowSummary;
+  reviewQueue: ReviewItem[];
+  setReviewQueue: Dispatch<SetStateAction<ReviewItem[]>>;
+}
+
+export default function ReviewView({
+  workflow,
+  reviewQueue,
+  setReviewQueue,
+}: ReviewViewProps) {
+  const setVerdict = (id: string, verdict: ReviewItem["verdict"]) => {
+    setReviewQueue((current) =>
+      current.map((item) => (item.id === id ? { ...item, verdict } : item)),
+    );
+  };
+
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>人工审核</h1>
+      <p style={{ margin: "0 0 18px", color: C.tx2, fontSize: 12 }}>
+        {workflow.name} · 低相似度判定
+      </p>
+
+      {reviewQueue.map((review) => (
+        <Panel
+          key={review.id}
+          style={{
+            padding: "14px 16px",
+            marginBottom: 10,
+            border: !review.verdict ? `1px solid ${C.warn}30` : `1px solid ${C.bd}`,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 10,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>{review.q}</span>
+              <StatusBadge tone="warning">{(review.sim * 100).toFixed(0)}%</StatusBadge>
+              {review.verdict && (
+                <StatusBadge
+                  tone={
+                    review.verdict === "equivalent"
+                      ? "success"
+                      : review.verdict === "not_eq"
+                        ? "danger"
+                        : "warning"
+                  }
+                >
+                  {review.verdict === "equivalent"
+                    ? "等价"
+                    : review.verdict === "not_eq"
+                      ? "不等价"
+                      : "可接受"}
+                </StatusBadge>
+              )}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 8,
+              marginBottom: 10,
+            }}
+          >
+            {[
+              { label: "Coze", value: review.cS, color: C.coze },
+              { label: "Dify", value: review.dS, color: C.dify },
+            ].map((side) => (
+              <div
+                key={side.label}
+                style={{
+                  padding: 10,
+                  borderRadius: 5,
+                  background: C.bg,
+                  border: `1px solid ${C.bd}`,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 700,
+                    color: side.color,
+                    marginBottom: 4,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {side.label}
+                </div>
+                <div style={{ fontSize: 12 }}>{side.value}</div>
+              </div>
+            ))}
+          </div>
+
+          {!review.verdict && (
+            <div style={{ display: "flex", gap: 5, justifyContent: "flex-end" }}>
+              <WorkbenchButton
+                compact
+                type="button"
+                variant="success"
+                onClick={() => setVerdict(review.id, "equivalent")}
+              >
+                等价
+              </WorkbenchButton>
+              <WorkbenchButton
+                compact
+                type="button"
+                onClick={() => setVerdict(review.id, "acceptable")}
+              >
+                可接受
+              </WorkbenchButton>
+              <WorkbenchButton
+                compact
+                type="button"
+                variant="danger"
+                onClick={() => setVerdict(review.id, "not_eq")}
+              >
+                不等价
+              </WorkbenchButton>
+            </div>
+          )}
+        </Panel>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/SandboxView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/SandboxView.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useRef, useState } from "react";
+import { C } from "../theme";
+import { SANDBOX_METRICS } from "../mockData";
+import type { SandboxMessage, SandboxStatus, WorkflowSummary } from "../types";
+import { buildSandboxReply, createMessageId } from "../utils";
+import Panel from "../components/Panel";
+import WorkbenchButton from "../components/WorkbenchButton";
+
+interface SandboxViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function SandboxView({ workflow }: SandboxViewProps) {
+  const [status, setStatus] = useState<SandboxStatus>("idle");
+  const [messages, setMessages] = useState<SandboxMessage[]>([]);
+  const [input, setInput] = useState("");
+  const timersRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    };
+  }, []);
+
+  const start = () => {
+    setStatus("starting");
+    timersRef.current.push(window.setTimeout(() => setStatus("running"), 1500));
+  };
+
+  const stop = () => {
+    timersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    timersRef.current = [];
+    setStatus("idle");
+    setMessages([]);
+  };
+
+  const send = () => {
+    const text = input.trim();
+    if (!text || status !== "running") {
+      return;
+    }
+
+    setInput("");
+    setMessages((current) => [...current, { id: createMessageId("user"), role: "user", text }]);
+
+    timersRef.current.push(
+      window.setTimeout(() => {
+        const reply = buildSandboxReply(text, "coze");
+        setMessages((current) => [
+          ...current,
+          {
+            id: createMessageId("coze"),
+            role: "coze",
+            text: reply.text,
+            latencyMs: reply.latencyMs,
+          },
+        ]);
+      }, 800),
+    );
+
+    timersRef.current.push(
+      window.setTimeout(() => {
+        const reply = buildSandboxReply(text, "dify");
+        setMessages((current) => [
+          ...current,
+          {
+            id: createMessageId("dify"),
+            role: "dify",
+            text: reply.text,
+            latencyMs: reply.latencyMs,
+          },
+        ]);
+      }, 1200),
+    );
+  };
+
+  const roleColors = {
+    user: C.acc,
+    coze: C.coze,
+    dify: C.dify,
+  } as const;
+
+  const roleLabels = {
+    user: "👤 输入",
+    coze: "🔵 Coze",
+    dify: "🟣 Dify",
+  } as const;
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 18 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>沙箱环境</h1>
+          <p style={{ margin: 0, color: C.tx2, fontSize: 12 }}>{workflow.name}</p>
+        </div>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+              padding: "3px 9px",
+              borderRadius: 12,
+              fontSize: 10,
+              fontWeight: 600,
+              background: status === "running" ? C.okD : `${C.tx3}15`,
+              color: status === "running" ? C.ok : C.tx3,
+            }}
+          >
+            <span
+              style={{
+                width: 5,
+                height: 5,
+                borderRadius: "50%",
+                background: status === "running" ? C.ok : C.tx3,
+              }}
+            />
+            {status === "idle" ? "未启动" : status === "starting" ? "启动中…" : "运行中"}
+          </div>
+          <WorkbenchButton
+            type="button"
+            variant={status === "idle" ? "success" : "danger"}
+            onClick={status === "idle" ? start : stop}
+          >
+            {status === "idle" ? "启动" : "停止"}
+          </WorkbenchButton>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 260px",
+          gap: 12,
+          height: 420,
+        }}
+      >
+        <Panel style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
+          <div style={{ flex: 1, overflow: "auto", padding: 12 }}>
+            {status !== "running" && messages.length === 0 ? (
+              <div
+                style={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: C.tx3,
+                }}
+              >
+                <div style={{ fontSize: 32, marginBottom: 8, opacity: 0.4 }}>🏖️</div>
+                <div style={{ fontSize: 12 }}>启动沙箱后对比</div>
+              </div>
+            ) : (
+              messages.map((message) => (
+                <div
+                  key={message.id}
+                  style={{
+                    marginBottom: 6,
+                    padding: "8px 10px",
+                    borderRadius: 5,
+                    background: `${roleColors[message.role]}10`,
+                    borderLeft: `3px solid ${roleColors[message.role]}`,
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      marginBottom: 2,
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 9,
+                        fontWeight: 700,
+                        color: roleColors[message.role],
+                      }}
+                    >
+                      {roleLabels[message.role]}
+                    </span>
+                    {message.latencyMs && (
+                      <span style={{ fontSize: 8, color: C.tx3 }}>{message.latencyMs}ms</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 12 }}>{message.text}</div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: 5,
+              padding: "8px 12px",
+              borderTop: `1px solid ${C.bd}`,
+            }}
+          >
+            <input
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  send();
+                }
+              }}
+              placeholder={status === "running" ? "输入消息…" : "先启动"}
+              disabled={status !== "running"}
+              style={{
+                flex: 1,
+                padding: "7px 10px",
+                borderRadius: 5,
+                background: C.bg,
+                border: `1px solid ${C.bd}`,
+                color: C.tx,
+                fontSize: 12,
+                fontFamily: C.ft,
+                outline: "none",
+              }}
+            />
+            <WorkbenchButton variant="primary" type="button" onClick={send}>
+              发送
+            </WorkbenchButton>
+          </div>
+        </Panel>
+
+        <Panel style={{ padding: "12px 14px" }}>
+          <div
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              color: C.tx3,
+              marginBottom: 8,
+              textTransform: "uppercase",
+            }}
+          >
+            实时指标
+          </div>
+          {SANDBOX_METRICS.map((metric, index) => (
+            <div
+              key={metric.label}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                padding: "4px 0",
+                borderBottom: index < SANDBOX_METRICS.length - 1 ? `1px solid ${C.bd}` : "none",
+              }}
+            >
+              <span style={{ fontSize: 10, color: C.tx3 }}>{metric.label}</span>
+              <div
+                style={{
+                  display: "flex",
+                  gap: 6,
+                  fontFamily: C.mono,
+                  fontSize: 10,
+                }}
+              >
+                <span style={{ color: C.coze }}>{metric.coze}</span>
+                <span style={{ color: C.tx3 }}>vs</span>
+                <span style={{ color: C.dify }}>{metric.dify}</span>
+              </div>
+            </div>
+          ))}
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/TestingView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/TestingView.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { C } from "../theme";
+import { ERROR_PATTERNS, TEST_CASES } from "../mockData";
+import type { WorkflowSummary } from "../types";
+import Panel from "../components/Panel";
+import SegmentTabs from "../components/SegmentTabs";
+import StatusBadge from "../components/StatusBadge";
+import WorkbenchButton from "../components/WorkbenchButton";
+import { IcCheck, IcX } from "../components/icons";
+
+type TestingTab = "cases" | "patterns";
+
+interface TestingViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function TestingView({ workflow }: TestingViewProps) {
+  const [tab, setTab] = useState<TestingTab>("cases");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const summaryCards = [
+    { label: "总用例", value: TEST_CASES.length, color: C.acc },
+    { label: "通过", value: TEST_CASES.filter((item) => item.status === "pass").length, color: C.ok },
+    { label: "失败", value: TEST_CASES.filter((item) => item.status === "fail").length, color: C.err },
+    { label: "错误模式", value: ERROR_PATTERNS.length, color: C.err },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 14 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>自动化测试</h1>
+          <p style={{ margin: 0, color: C.tx2, fontSize: 12 }}>{workflow.name}</p>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <WorkbenchButton variant="primary" type="button">
+            AI 生成
+          </WorkbenchButton>
+          <WorkbenchButton variant="success" type="button">
+            全部运行
+          </WorkbenchButton>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4,1fr)",
+          gap: 8,
+          marginBottom: 14,
+        }}
+      >
+        {summaryCards.map((card) => (
+          <Panel
+            key={card.label}
+            style={{
+              padding: "10px 14px",
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                fontFamily: C.mono,
+                color: card.color,
+              }}
+            >
+              {card.value}
+            </span>
+            <span style={{ fontSize: 10, color: C.tx2 }}>{card.label}</span>
+          </Panel>
+        ))}
+      </div>
+
+      <SegmentTabs
+        activeKey={tab}
+        items={[
+          { key: "cases", label: "用例", icon: <span>🧪</span> },
+          { key: "patterns", label: "错误模式", icon: <span>🔍</span> },
+        ]}
+        onChange={setTab}
+      />
+
+      <div style={{ marginTop: 12 }}>
+        {tab === "cases" && (
+          <Panel>
+            {TEST_CASES.map((test, index) => {
+              const expanded = expandedId === test.id;
+              const similarityColor =
+                test.sim >= 0.85 ? C.ok : test.sim >= 0.5 ? C.warn : C.err;
+              const errorPattern = ERROR_PATTERNS.find((pattern) => pattern.key === test.ep);
+
+              return (
+                <div
+                  key={test.id}
+                  style={{
+                    borderBottom: index < TEST_CASES.length - 1 ? `1px solid ${C.bd}` : "none",
+                  }}
+                >
+                  <div
+                    onClick={() => setExpandedId(expanded ? null : test.id)}
+                    style={{
+                      padding: "10px 14px",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      cursor: "pointer",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: 4,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: test.status === "pass" ? C.okD : C.errD,
+                        color: test.status === "pass" ? C.ok : C.err,
+                      }}
+                    >
+                      {test.status === "pass" ? <IcCheck /> : <IcX />}
+                    </span>
+                    <div style={{ flex: 1, fontSize: 12, fontWeight: 500 }}>{test.name}</div>
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontFamily: C.mono,
+                        fontWeight: 700,
+                        color: similarityColor,
+                      }}
+                    >
+                      {(test.sim * 100).toFixed(0)}%
+                    </span>
+                    <span style={{ fontSize: 10, fontFamily: C.mono, color: C.tx3 }}>
+                      {test.dL > 0 ? `${test.dL}ms` : "ERR"}
+                    </span>
+                    {errorPattern && <StatusBadge tone="danger">{errorPattern.name}</StatusBadge>}
+                    <span
+                      style={{
+                        color: C.tx3,
+                        transform: expanded ? "rotate(180deg)" : "none",
+                        transition: "transform .2s",
+                        display: "inline-block",
+                      }}
+                    >
+                      ▾
+                    </span>
+                  </div>
+
+                  {expanded && (
+                    <div
+                      style={{
+                        padding: "0 14px 14px",
+                        borderTop: `1px dashed ${C.bd}`,
+                        paddingTop: 10,
+                        display: "grid",
+                        gridTemplateColumns: "1fr 1fr 1fr",
+                        gap: 8,
+                      }}
+                    >
+                      {[
+                        { label: "输入", color: C.acc, value: test.input || "(空)" },
+                        { label: "Coze", color: C.coze, value: test.cOut },
+                        { label: "Dify", color: C.dify, value: test.dOut },
+                      ].map((column) => (
+                        <div key={column.label}>
+                          <div
+                            style={{
+                              fontSize: 9,
+                              fontWeight: 700,
+                              color: column.color,
+                              marginBottom: 4,
+                              textTransform: "uppercase",
+                            }}
+                          >
+                            {column.label}
+                          </div>
+                          <div
+                            style={{
+                              padding: 8,
+                              borderRadius: 4,
+                              background: C.bg,
+                              border: `1px solid ${C.bd}`,
+                              fontSize: 11,
+                              fontFamily: C.mono,
+                              minHeight: 40,
+                              color: column.value.includes("ERROR") ? C.err : C.tx,
+                            }}
+                          >
+                            {column.value}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </Panel>
+        )}
+
+        {tab === "patterns" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {ERROR_PATTERNS.map((pattern) => (
+              <Panel key={pattern.id} style={{ padding: "14px 16px" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    marginBottom: 8,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 32,
+                      height: 32,
+                      borderRadius: 7,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 14,
+                      fontWeight: 700,
+                      fontFamily: C.mono,
+                      background: pattern.sev === "critical" ? C.errD : C.warnD,
+                      color: pattern.sev === "critical" ? C.err : C.warn,
+                    }}
+                  >
+                    {pattern.count}
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: 13, fontWeight: 600 }}>
+                      {pattern.name}{" "}
+                      <StatusBadge tone={pattern.sev === "critical" ? "danger" : "warning"}>
+                        {pattern.sev === "critical" ? "严重" : "高"}
+                      </StatusBadge>
+                    </div>
+                    <div style={{ fontSize: 11, color: C.tx2 }}>{pattern.desc}</div>
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: 4,
+                    background: C.bg,
+                    border: `1px solid ${C.bd}`,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 9,
+                      fontWeight: 700,
+                      color: C.ok,
+                      marginBottom: 2,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    修复建议
+                  </div>
+                  <div style={{ fontSize: 11 }}>{pattern.fix}</div>
+                </div>
+              </Panel>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/views/TopologyView.tsx
+++ b/frontend/src/features/migrationWorkbench/views/TopologyView.tsx
@@ -1,0 +1,109 @@
+import { C } from "../theme";
+import { DAG_COZE, DAG_DIFY, STRUCTURE_DIFFS } from "../mockData";
+import type { WorkflowSummary } from "../types";
+import { getSeverityTone } from "../utils";
+import DagGraph from "../components/DagGraph";
+import Panel from "../components/Panel";
+import SectionHeader from "../components/SectionHeader";
+import StatusBadge from "../components/StatusBadge";
+
+interface TopologyViewProps {
+  workflow: WorkflowSummary;
+}
+
+export default function TopologyView({ workflow }: TopologyViewProps) {
+  return (
+    <div>
+      <h1 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 4px" }}>DAG 拓扑对比</h1>
+      <p style={{ margin: "0 0 18px", color: C.tx2, fontSize: 12 }}>
+        {workflow.name} · 结构差异
+      </p>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+          marginBottom: 16,
+        }}
+      >
+        {[
+          { label: "Coze", graph: DAG_COZE, color: C.coze, platform: "coze" as const },
+          { label: "Dify", graph: DAG_DIFY, color: C.dify, platform: "dify" as const },
+        ].map((side) => (
+          <Panel key={side.label} style={{ padding: "12px 14px" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                marginBottom: 8,
+              }}
+            >
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 3,
+                  background: side.color,
+                }}
+              />
+              <span style={{ fontSize: 11, fontWeight: 600, color: side.color }}>
+                {side.label}
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  color: C.tx3,
+                  fontFamily: C.mono,
+                  marginLeft: "auto",
+                }}
+              >
+                {side.graph.nodes.length}节点 · {side.graph.edges.length}连线
+              </span>
+            </div>
+            <div
+              style={{
+                height: 200,
+                background: C.bg,
+                borderRadius: 5,
+                border: `1px solid ${C.bd}`,
+                padding: 6,
+              }}
+            >
+              <DagGraph graph={side.graph} platform={side.platform} />
+            </div>
+          </Panel>
+        ))}
+      </div>
+
+      <Panel style={{ padding: "14px 16px" }}>
+        <SectionHeader>结构差异</SectionHeader>
+        {STRUCTURE_DIFFS.map((item) => {
+          const tone = getSeverityTone(item.sev);
+          const color = tone === "danger" ? C.err : tone === "warning" ? C.warn : C.acc;
+          const background = tone === "danger" ? C.errD : tone === "warning" ? C.warnD : C.accD;
+
+          return (
+            <div
+              key={item.text}
+              style={{
+                padding: "8px 12px",
+                borderRadius: 5,
+                marginBottom: 5,
+                fontSize: 12,
+                background,
+                border: `1px solid ${color}20`,
+              }}
+            >
+              <StatusBadge tone={tone}>
+                {item.sev === "high" ? "HIGH" : item.sev === "medium" ? "MED" : "LOW"}
+              </StatusBadge>
+              <span style={{ marginLeft: 6 }}>{item.text}</span>
+            </div>
+          );
+        })}
+      </Panel>
+    </div>
+  );
+}

--- a/frontend/src/features/migrationWorkbench/workbench.css
+++ b/frontend/src/features/migrationWorkbench/workbench.css
@@ -1,0 +1,53 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&display=swap');
+
+.mw-root {
+  width: 100%;
+  min-height: 100vh;
+}
+
+.mw-root,
+.mw-root * {
+  box-sizing: border-box;
+}
+
+.mw-root * {
+  margin: 0;
+  padding: 0;
+}
+
+.mw-root ::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.mw-root ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.mw-root ::-webkit-scrollbar-thumb {
+  background: #263a5a;
+  border-radius: 2px;
+}
+
+.mw-root input[type="range"] {
+  -webkit-appearance: none;
+  height: 3px;
+  background: #1c2a48;
+  border-radius: 2px;
+  outline: none;
+}
+
+.mw-root input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #00d4ff;
+  cursor: pointer;
+  border: 2px solid #060a12;
+}
+
+.mw-root input::placeholder {
+  color: #4d5f7a;
+  opacity: 0.5;
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2,6 +2,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "migrate": "Migrate",
+    "workbench": "Workbench",
     "sync": "Sync",
     "history": "History",
     "settings": "Settings"

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -2,6 +2,7 @@
   "nav": {
     "dashboard": "仪表盘",
     "migrate": "迁移",
+    "workbench": "工作台",
     "sync": "同步",
     "history": "历史",
     "settings": "设置"

--- a/frontend/src/pages/MigrationWorkbenchPage.tsx
+++ b/frontend/src/pages/MigrationWorkbenchPage.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import WorkbenchShell from "../features/migrationWorkbench/components/WorkbenchShell";
+import { REVIEW_QUEUE, WORKFLOWS } from "../features/migrationWorkbench/mockData";
+import type {
+  ReviewItem,
+  WorkbenchPageKey,
+} from "../features/migrationWorkbench/types";
+import EquivalenceView from "../features/migrationWorkbench/views/EquivalenceView";
+import KnowledgeView from "../features/migrationWorkbench/views/KnowledgeView";
+import OverviewView from "../features/migrationWorkbench/views/OverviewView";
+import ReleaseView from "../features/migrationWorkbench/views/ReleaseView";
+import ReviewView from "../features/migrationWorkbench/views/ReviewView";
+import SandboxView from "../features/migrationWorkbench/views/SandboxView";
+import TestingView from "../features/migrationWorkbench/views/TestingView";
+import TopologyView from "../features/migrationWorkbench/views/TopologyView";
+import "../features/migrationWorkbench/workbench.css";
+
+export default function MigrationWorkbenchPage() {
+  const [activePage, setActivePage] = useState<WorkbenchPageKey>("dashboard");
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState(WORKFLOWS[0]?.id ?? "");
+  const [reviewQueue, setReviewQueue] = useState<ReviewItem[]>(REVIEW_QUEUE);
+
+  const selectedWorkflow =
+    WORKFLOWS.find((workflow) => workflow.id === selectedWorkflowId) ?? WORKFLOWS[0];
+
+  const handleInspectWorkflow = (workflowId: string) => {
+    setSelectedWorkflowId(workflowId);
+    setActivePage("equiv");
+  };
+
+  return (
+    <div className="mw-root">
+      <WorkbenchShell
+        activePage={activePage}
+        onNavigate={setActivePage}
+        workflows={WORKFLOWS}
+        selectedWorkflow={selectedWorkflow}
+        onWorkflowSelect={setSelectedWorkflowId}
+      >
+        {renderPage(
+          activePage,
+          selectedWorkflow.id,
+          reviewQueue,
+          setReviewQueue,
+          handleInspectWorkflow,
+        )}
+      </WorkbenchShell>
+    </div>
+  );
+}
+
+function renderPage(
+  page: WorkbenchPageKey,
+  workflowId: string,
+  reviewQueue: ReviewItem[],
+  setReviewQueue: React.Dispatch<React.SetStateAction<ReviewItem[]>>,
+  onInspectWorkflow: (workflowId: string) => void,
+) {
+  const workflow = WORKFLOWS.find((item) => item.id === workflowId) ?? WORKFLOWS[0];
+
+  switch (page) {
+    case "dashboard":
+      return (
+        <OverviewView
+          onInspectWorkflow={onInspectWorkflow}
+          reviewQueue={reviewQueue}
+          workflows={WORKFLOWS}
+        />
+      );
+    case "dag":
+      return <TopologyView workflow={workflow} />;
+    case "equiv":
+      return <EquivalenceView workflow={workflow} />;
+    case "test":
+      return <TestingView workflow={workflow} />;
+    case "canary":
+      return <ReleaseView workflow={workflow} />;
+    case "kb":
+      return <KnowledgeView workflow={workflow} />;
+    case "review":
+      return (
+        <ReviewView
+          reviewQueue={reviewQueue}
+          setReviewQueue={setReviewQueue}
+          workflow={workflow}
+        />
+      );
+    case "sandbox":
+      return <SandboxView workflow={workflow} />;
+    default:
+      return (
+        <OverviewView
+          onInspectWorkflow={onInspectWorkflow}
+          reviewQueue={reviewQueue}
+          workflows={WORKFLOWS}
+        />
+      );
+  }
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -11,6 +11,7 @@ import SyncRunDetailPage from "./pages/SyncRunDetailPage";
 import UnifiedHistoryPage from "./pages/UnifiedHistoryPage";
 import ConversionDetailPage from "./pages/ConversionDetailPage";
 import SettingsPage from "./pages/SettingsPage";
+import MigrationWorkbenchPage from "./pages/MigrationWorkbenchPage";
 
 export function AppRoutes() {
   return (
@@ -36,6 +37,7 @@ export function AppRoutes() {
 
       {/* Settings */}
       <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/workbench" element={<MigrationWorkbenchPage />} />
 
       {/* Backward compatibility redirects */}
       <Route path="/diff/:conversionId" element={<RedirectDiff />} />


### PR DESCRIPTION
## Summary
- add a dedicated `/workbench` route with a full-screen shell so the Migration QA workbench can match the approved reference instead of inheriting the existing app chrome
- implement the workbench as a modular React feature split into theme, mock data, shared components, and per-view sections while preserving the reference layout and interactions
- expose the route in navigation and update issue #36 so it matches the actual frontend parity scope

## Verification
- `npm run build` (frontend)
- local Playwright screenshot capture for `http://127.0.0.1:4173/workbench`
- repository push gate:
  - backend import smoke on Python 3.10 / 3.11 / 3.12
  - backend lint and tests: `83 passed, 2 skipped`
  - frontend build
  - migration e2e smoke: `1 passed`

Closes #36
