### PR TITLE
fix: stabilize workbench persisted state flows

### DIFF
--- a/backend/api/endpoints/workbench.py
+++ b/backend/api/endpoints/workbench.py
@@ -38,86 +38,95 @@ async def get_workbench_overview(
 
 
 @router.post("/batch-migrate")
-async def batch_migrate_workflows():
-    return service.batch_migrate()
+async def batch_migrate_workflows(db: Session = Depends(get_db)):
+    return service.batch_migrate(db)
 
 
 @router.get("/workflows/{workflow_id}/topology")
-async def get_workflow_topology(workflow_id: str):
+async def get_workflow_topology(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_topology(workflow_id)
+        return service.get_topology(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/equivalence")
-async def get_workflow_equivalence(workflow_id: str):
+async def get_workflow_equivalence(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_equivalence(workflow_id)
+        return service.get_equivalence(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/tests")
-async def get_workflow_tests(workflow_id: str):
+async def get_workflow_tests(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_tests(workflow_id)
+        return service.get_tests(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/tests/generate")
-async def generate_workflow_tests(workflow_id: str):
+async def generate_workflow_tests(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.generate_tests(workflow_id)
+        return service.generate_tests(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/tests/run")
-async def run_workflow_tests(workflow_id: str):
+async def run_workflow_tests(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.run_tests(workflow_id)
+        return service.run_tests(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/knowledge")
-async def get_workflow_knowledge(workflow_id: str):
+async def get_workflow_knowledge(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_knowledge(workflow_id)
+        return service.get_knowledge(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/review")
-async def get_workflow_review(workflow_id: str):
+async def get_workflow_review(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_review_queue(workflow_id)
+        return service.get_review_queue(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/review/{review_id}")
-async def update_review_verdict(workflow_id: str, review_id: str, req: ReviewVerdictRequest):
+async def update_review_verdict(
+    workflow_id: str,
+    review_id: str,
+    req: ReviewVerdictRequest,
+    db: Session = Depends(get_db),
+):
     try:
-        return service.update_review_verdict(workflow_id, review_id, req.verdict)
+        return service.update_review_verdict(workflow_id, review_id, req.verdict, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/release")
-async def get_workflow_release(workflow_id: str):
+async def get_workflow_release(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_release(workflow_id)
+        return service.get_release(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/release/traffic")
-async def update_workflow_traffic(workflow_id: str, req: TrafficRequest):
+async def update_workflow_traffic(
+    workflow_id: str,
+    req: TrafficRequest,
+    db: Session = Depends(get_db),
+):
     try:
-        return service.update_traffic(workflow_id, req.traffic)
+        return service.update_traffic(workflow_id, req.traffic, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -125,41 +134,49 @@ async def update_workflow_traffic(workflow_id: str, req: TrafficRequest):
 
 
 @router.post("/workflows/{workflow_id}/release/rollback")
-async def rollback_workflow_release(workflow_id: str, req: RollbackRequest):
+async def rollback_workflow_release(
+    workflow_id: str,
+    req: RollbackRequest,
+    db: Session = Depends(get_db),
+):
     try:
-        return service.rollback_release(workflow_id, req.version)
+        return service.rollback_release(workflow_id, req.version, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/workflows/{workflow_id}/sandbox")
-async def get_workflow_sandbox(workflow_id: str):
+async def get_workflow_sandbox(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.get_sandbox(workflow_id)
+        return service.get_sandbox(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/sandbox/start")
-async def start_workflow_sandbox(workflow_id: str):
+async def start_workflow_sandbox(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.start_sandbox(workflow_id)
+        return service.start_sandbox(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/sandbox/stop")
-async def stop_workflow_sandbox(workflow_id: str):
+async def stop_workflow_sandbox(workflow_id: str, db: Session = Depends(get_db)):
     try:
-        return service.stop_sandbox(workflow_id)
+        return service.stop_sandbox(workflow_id, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/workflows/{workflow_id}/sandbox/messages")
-async def send_workflow_sandbox_message(workflow_id: str, req: SandboxMessageRequest):
+async def send_workflow_sandbox_message(
+    workflow_id: str,
+    req: SandboxMessageRequest,
+    db: Session = Depends(get_db),
+):
     try:
-        return service.send_sandbox_message(workflow_id, req.text)
+        return service.send_sandbox_message(workflow_id, req.text, db)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:

--- a/backend/core/workbench/service.py
+++ b/backend/core/workbench/service.py
@@ -31,100 +31,112 @@ class WorkbenchService:
     def reset(self) -> None:
         with self._lock:
             self._workflows = deepcopy(WORKFLOWS)
+            self._workflow_overrides: dict[str, dict[str, Any]] = {}
             self._test_cases = deepcopy(TEST_CASES)
             self._review_queue = deepcopy(REVIEW_QUEUE)
             self._release_state: dict[str, dict[str, Any]] = {}
             self._sandbox_state: dict[str, dict[str, Any]] = {}
 
     def get_overview(self, db: Session | None = None, *, limit: int = 50) -> dict[str, Any]:
-        if db is not None:
-            workflows = self._load_persisted_overview(db, limit=limit)
-            if workflows:
-                pending_reviews = sum(1 for workflow in workflows if workflow.get("requiresManualReview"))
-                return {
-                    "summary": self._build_summary(workflows, pending_reviews=pending_reviews),
-                    "workflows": workflows,
-                }
+        workflows = self._get_visible_workflows(db, limit=limit)
+        if db is not None and self._has_persisted_overview(db):
+            pending_reviews = sum(1 for workflow in workflows if workflow.get("requiresManualReview"))
+            return {
+                "summary": self._build_summary(workflows, pending_reviews=pending_reviews),
+                "workflows": workflows,
+            }
 
-        workflows = deepcopy(self._workflows[:limit])
         return {
             "summary": self._build_summary(workflows),
             "workflows": workflows,
         }
 
-    def batch_migrate(self) -> dict[str, Any]:
+    def batch_migrate(self, db: Session | None = None, *, limit: int = 50) -> dict[str, Any]:
         with self._lock:
-            for workflow in self._workflows:
-                if workflow["status"] == "pending":
-                    workflow["status"] = "testing"
-                    workflow["difyId"] = f"app-auto-{workflow['cozeId'].split('_')[-1]}"
-                    workflow["migrated"] = workflow["nodes"]
-                    workflow["failed"] = 0
-                    workflow["score"] = 96.4
-                    workflow["lastSync"] = "2026-03-13"
-            return self.get_overview()
+            if db is not None and self._has_persisted_overview(db):
+                for workflow in self._load_persisted_overview(db, limit=limit):
+                    if workflow["status"] == "pending":
+                        self._workflow_overrides[workflow["id"]] = self._build_batch_migrate_patch(workflow)
+            else:
+                for workflow in self._workflows:
+                    if workflow["status"] == "pending":
+                        workflow.update(self._build_batch_migrate_patch(workflow))
+        return self.get_overview(db, limit=limit)
 
-    def get_topology(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_topology(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         return deepcopy(TOPOLOGY)
 
-    def get_equivalence(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_equivalence(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         return deepcopy(EQUIVALENCE)
 
-    def get_tests(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_tests(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         return {
             "cases": deepcopy(self._test_cases),
             "patterns": self._build_error_patterns(),
         }
 
-    def generate_tests(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def generate_tests(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             exists = any(item["id"] == GENERATED_TEST_CASE["id"] for item in self._test_cases)
             if not exists:
                 self._test_cases.append(deepcopy(GENERATED_TEST_CASE))
-        payload = self.get_tests(workflow_id)
+        payload = self.get_tests(workflow_id, db)
         payload["generated"] = 0 if exists else 1
         return payload
 
-    def run_tests(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
-        payload = self.get_tests(workflow_id)
+    def run_tests(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
+        payload = self.get_tests(workflow_id, db)
         payload["executed"] = len(payload["cases"])
         payload["lastRunAt"] = "2026-03-13T00:00:00"
         return payload
 
-    def get_knowledge(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_knowledge(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         return {"records": deepcopy(KNOWLEDGE_BASES)}
 
-    def get_review_queue(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_review_queue(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         return {"items": deepcopy(self._review_queue)}
 
-    def update_review_verdict(self, workflow_id: str, review_id: str, verdict: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def update_review_verdict(
+        self,
+        workflow_id: str,
+        review_id: str,
+        verdict: str,
+        db: Session | None = None,
+    ) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             review = next((item for item in self._review_queue if item["id"] == review_id), None)
             if review is None:
                 raise LookupError(f"Unknown review item: {review_id}")
             review["verdict"] = verdict
-            return {
-                "item": deepcopy(review),
-                "items": deepcopy(self._review_queue),
-                "summary": self._build_summary(self._workflows),
-            }
+            item = deepcopy(review)
+            items = deepcopy(self._review_queue)
+        return {
+            "item": item,
+            "items": items,
+            "summary": self.get_overview(db)["summary"],
+        }
 
-    def get_release(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_release(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             state = self._release_state.setdefault(workflow_id, deepcopy(RELEASE_STATE))
             return deepcopy(state)
 
-    def update_traffic(self, workflow_id: str, traffic: int) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def update_traffic(
+        self,
+        workflow_id: str,
+        traffic: int,
+        db: Session | None = None,
+    ) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         if traffic < 0 or traffic > 100:
             raise ValueError("Traffic must be between 0 and 100")
         with self._lock:
@@ -133,8 +145,13 @@ class WorkbenchService:
             state["stages"] = self._build_stages(traffic)
             return deepcopy(state)
 
-    def rollback_release(self, workflow_id: str, version: str | None = None) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def rollback_release(
+        self,
+        workflow_id: str,
+        version: str | None = None,
+        db: Session | None = None,
+    ) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             state = self._release_state.setdefault(workflow_id, deepcopy(RELEASE_STATE))
             target = version or next(
@@ -165,8 +182,8 @@ class WorkbenchService:
             state["stages"] = self._build_stages(20)
             return deepcopy(state)
 
-    def get_sandbox(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def get_sandbox(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             state = self._sandbox_state.setdefault(
                 workflow_id,
@@ -179,8 +196,8 @@ class WorkbenchService:
             )
             return self._serialize_sandbox(state)
 
-    def start_sandbox(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def start_sandbox(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             state = self._sandbox_state.setdefault(
                 workflow_id,
@@ -189,8 +206,8 @@ class WorkbenchService:
             state["status"] = "running"
             return self._serialize_sandbox(state)
 
-    def stop_sandbox(self, workflow_id: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def stop_sandbox(self, workflow_id: str, db: Session | None = None) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         with self._lock:
             state = self._sandbox_state.setdefault(
                 workflow_id,
@@ -202,8 +219,13 @@ class WorkbenchService:
             state["counter"] = 0
             return self._serialize_sandbox(state)
 
-    def send_sandbox_message(self, workflow_id: str, text: str) -> dict[str, Any]:
-        self._require_workflow(workflow_id)
+    def send_sandbox_message(
+        self,
+        workflow_id: str,
+        text: str,
+        db: Session | None = None,
+    ) -> dict[str, Any]:
+        self._require_workflow(workflow_id, db)
         cleaned = text.strip()
         if not cleaned:
             raise ValueError("Message text is required")
@@ -236,6 +258,17 @@ class WorkbenchService:
                 )
             )
             return self._serialize_sandbox(state)
+
+    def _get_visible_workflows(
+        self,
+        db: Session | None = None,
+        *,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        if db is not None and self._has_persisted_overview(db):
+            workflows = self._load_persisted_overview(db, limit=limit)
+            return self._apply_workflow_overrides(workflows)
+        return deepcopy(self._workflows[:limit])
 
     def _load_persisted_overview(self, db: Session, *, limit: int) -> list[dict[str, Any]]:
         tasks = (
@@ -416,6 +449,44 @@ class WorkbenchService:
         total = sum(ord(char) for char in text)
         return 800 + (total % 1201), 600 + (total % 1001)
 
+    def _has_persisted_overview(self, db: Session) -> bool:
+        return db.query(MigrationTask.id).filter(MigrationTask.sync_config_id.is_(None)).first() is not None
+
+    def _find_persisted_task(self, db: Session, workflow_id: str) -> MigrationTask | None:
+        task = (
+            db.query(MigrationTask)
+            .filter(MigrationTask.sync_config_id.is_(None))
+            .filter(MigrationTask.source_workflow_id == workflow_id)
+            .order_by(MigrationTask.id.desc())
+            .first()
+        )
+        if task is not None or not workflow_id.isdigit():
+            return task
+        return (
+            db.query(MigrationTask)
+            .filter(MigrationTask.sync_config_id.is_(None))
+            .filter(MigrationTask.id == int(workflow_id))
+            .first()
+        )
+
+    def _apply_workflow_overrides(self, workflows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for workflow in workflows:
+            override = self._workflow_overrides.get(workflow["id"])
+            result.append({**workflow, **override} if override else workflow)
+        return result
+
+    @staticmethod
+    def _build_batch_migrate_patch(workflow: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "status": "testing",
+            "difyId": workflow.get("difyId") or f"app-auto-{str(workflow['cozeId']).split('_')[-1]}",
+            "migrated": workflow["nodes"],
+            "failed": 0,
+            "score": 96.4,
+            "lastSync": "2026-03-13",
+        }
+
     @staticmethod
     def _derive_status(
         *,
@@ -442,10 +513,16 @@ class WorkbenchService:
             return "medium"
         return "low"
 
-    @staticmethod
-    def _require_workflow(workflow_id: str) -> None:
-        if not workflow_id.strip():
+    def _require_workflow(self, workflow_id: str, db: Session | None = None) -> None:
+        cleaned = workflow_id.strip()
+        if not cleaned:
             raise LookupError("Unknown workflow: <empty>")
+        if db is not None and self._has_persisted_overview(db):
+            if self._find_persisted_task(db, cleaned) is None:
+                raise LookupError(f"Unknown workflow: {cleaned}")
+            return
+        if not any(workflow["id"] == cleaned for workflow in self._workflows):
+            raise LookupError(f"Unknown workflow: {cleaned}")
 
 
 def _coerce_optional_string(value: Any) -> str | None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -6,7 +8,24 @@ from api.endpoints import sync as sync_endpoints
 from db.database import Base, engine
 from db import models as _db_models  # noqa: F401
 
-app = FastAPI(title="Coze2Dify", description="Coze to Dify workflow migration tool", version="0.1.0")
+
+def ensure_project_tables() -> None:
+    Base.metadata.create_all(bind=engine)
+    sync_endpoints.restore_schedules()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    ensure_project_tables()
+    yield
+
+
+app = FastAPI(
+    title="Coze2Dify",
+    description="Coze to Dify workflow migration tool",
+    version="0.1.0",
+    lifespan=lifespan,
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -23,12 +42,6 @@ app.add_middleware(
 )
 
 app.include_router(api_router, prefix="/api/v1")
-
-
-@app.on_event("startup")
-def ensure_project_tables() -> None:
-    Base.metadata.create_all(bind=engine)
-    sync_endpoints.restore_schedules()
 
 
 @app.get("/health")

--- a/backend/tests/test_workbench_api.py
+++ b/backend/tests/test_workbench_api.py
@@ -192,6 +192,51 @@ def test_workbench_mock_overview_and_batch_migrate_flow(tmp_path) -> None:
     assert migrated_payload["workflows"][2]["score"] == 96.4
 
 
+def test_workbench_batch_migrate_preserves_persisted_overview(tmp_path) -> None:
+    session_factory = _make_session_factory(tmp_path)
+    with session_factory() as db:
+        _seed_overview_history(db)
+        db.add(
+            MigrationTask(
+                source_type="upload",
+                source_workflow_id="wf-pending",
+                source_workflow_name="Pending Flow",
+                status="pending",
+                ir_snapshot={},
+                report={
+                    "workflow_name": "Pending Flow",
+                    "supported": True,
+                    "requires_manual_review": False,
+                    "total_nodes": 5,
+                    "mapped_count": 0,
+                    "partial_count": 0,
+                    "skipped_count": 0,
+                },
+                completed_at=datetime(2026, 3, 13, 8, 0, 0),
+            )
+        )
+        db.commit()
+
+    client = _make_client(session_factory)
+
+    migrated = client.post("/api/v1/workbench/batch-migrate")
+    assert migrated.status_code == 200
+    migrated_payload = migrated.json()
+    assert all(workflow["id"] != "wf1" for workflow in migrated_payload["workflows"])
+
+    pending = next(workflow for workflow in migrated_payload["workflows"] if workflow["id"] == "wf-pending")
+    assert pending["status"] == "testing"
+    assert pending["difyId"] == "app-auto-wf-pending"
+    assert pending["migrated"] == 5
+    assert pending["failed"] == 0
+    assert pending["score"] == 96.4
+
+    refreshed = client.get("/api/v1/workbench/overview?limit=10")
+    assert refreshed.status_code == 200
+    refreshed_pending = next(workflow for workflow in refreshed.json()["workflows"] if workflow["id"] == "wf-pending")
+    assert refreshed_pending["status"] == "testing"
+
+
 def test_workbench_analysis_endpoints_return_expected_payloads(tmp_path) -> None:
     client = _make_client(_make_session_factory(tmp_path))
 
@@ -281,3 +326,39 @@ def test_workbench_tests_review_release_and_sandbox_mutations(tmp_path) -> None:
     assert stop.status_code == 200
     assert stop.json()["status"] == "idle"
     assert stop.json()["messages"] == []
+
+    unknown = client.post("/api/v1/workbench/workflows/not-real/sandbox/start")
+    assert unknown.status_code == 404
+    assert unknown.json()["detail"] == "Unknown workflow: not-real"
+
+
+def test_workbench_persisted_actions_use_real_summary_and_reject_demo_ids(tmp_path) -> None:
+    session_factory = _make_session_factory(tmp_path)
+    with session_factory() as db:
+        _seed_overview_history(db)
+
+    client = _make_client(session_factory)
+
+    updated_review = client.post(
+        "/api/v1/workbench/workflows/wf-alpha/review/r1",
+        json={"verdict": "equivalent"},
+    )
+    assert updated_review.status_code == 200
+    updated_payload = updated_review.json()
+    assert updated_payload["summary"] == {
+        "totalWorkflows": 3,
+        "verifiedWorkflows": 1,
+        "averageScore": 83.1,
+        "totalNodes": 24,
+        "migratedNodes": 16,
+        "failedNodes": 8,
+        "pendingReviews": 1,
+    }
+
+    demo_workflow = client.get("/api/v1/workbench/workflows/wf1/topology")
+    assert demo_workflow.status_code == 404
+    assert demo_workflow.json()["detail"] == "Unknown workflow: wf1"
+
+    unknown = client.post("/api/v1/workbench/workflows/not-real/sandbox/start")
+    assert unknown.status_code == 404
+    assert unknown.json()["detail"] == "Unknown workflow: not-real"

--- a/frontend/src/features/migrationWorkbench/useWorkbenchData.ts
+++ b/frontend/src/features/migrationWorkbench/useWorkbenchData.ts
@@ -240,7 +240,10 @@ export default function useWorkbenchData() {
         current
           ? {
               ...current,
-              summary: payload.summary,
+              summary: {
+                ...current.summary,
+                pendingReviews: payload.summary.pendingReviews,
+              },
             }
           : current,
       );


### PR DESCRIPTION
## Summary
- keep workbench overview on persisted workflows after batch migrate and review actions
- reject unknown workflow ids across workbench action endpoints
- switch FastAPI startup initialization to lifespan and keep frontend overview summary updates scoped

## Testing
- cd backend && .venv/bin/python -m pytest tests/test_workbench_api.py -q
- cd backend && .venv/bin/python -m pytest tests/test_sync_api.py -q
- cd backend && .venv/bin/python -m pytest -q
- cd backend && .venv/bin/python -m ruff check .
- cd frontend && npm run build