### PR TITLE
Expand lint gate to migration workbench

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "max dev",
     "build": "max build",
-    "lint": "max lint --eslint-only \"src/{api,store,types}/**/*.{ts,tsx}\"",
+    "lint": "max lint --eslint-only \"src/{api,store,types,features/migrationWorkbench}/**/*.{ts,tsx}\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "postinstall": "max setup",

--- a/frontend/src/features/migrationWorkbench/components/WorkbenchButton.tsx
+++ b/frontend/src/features/migrationWorkbench/components/WorkbenchButton.tsx
@@ -14,6 +14,7 @@ export default function WorkbenchButton({
   compact = false,
   children,
   style,
+  type = "button",
   ...props
 }: WorkbenchButtonProps) {
   const scheme = {
@@ -25,6 +26,7 @@ export default function WorkbenchButton({
 
   return (
     <button
+      type={type === "submit" ? "submit" : type === "reset" ? "reset" : "button"}
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -68,6 +68,7 @@ run_backend_checks
 log_section "Frontend tests and build"
 (
   cd "${ROOT_DIR}/frontend"
+  npm run lint
   npm run test
   npx tsc --noEmit
   npm run build


### PR DESCRIPTION
## Summary
- add the migration workbench feature to the frontend ESLint scope
- fix the remaining `button-has-type` violation in `WorkbenchButton`
- run frontend lint in `scripts/ci-local.sh` for better local/CI parity

Closes #101

## Validation
- cd frontend && npm run lint
- cd frontend && npm run test
- cd frontend && npx tsc --noEmit
- cd frontend && npm run build
- bash -n scripts/ci-local.sh