### PR TITLE
Expand lint gate to lightweight pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "max dev",
     "build": "max build",
-    "lint": "max lint --eslint-only \"src/{api,store,types,features/migrationWorkbench}/**/*.{ts,tsx}\"",
+    "lint": "max lint --eslint-only \"src/{api,store,types,features/migrationWorkbench}/**/*.{ts,tsx}\" \"src/pages/{ConversionHistoryPage,DiffPage,MigratePage,ResultPage,SettingsPage,UploadPage}.tsx\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "postinstall": "max setup",

--- a/frontend/src/pages/ConversionHistoryPage.tsx
+++ b/frontend/src/pages/ConversionHistoryPage.tsx
@@ -72,6 +72,7 @@ export default function ConversionHistoryPage() {
           <div className="alert alert--error">{error}</div>
           <div>
             <button
+              type="button"
               className="btn btn-secondary"
               onClick={() => setReloadKey((value) => value + 1)}
             >
@@ -147,6 +148,7 @@ export default function ConversionHistoryPage() {
 
             <div style={{ display: "flex", gap: 10 }}>
               <button
+                type="button"
                 className="btn btn-ghost"
                 onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
                 disabled={offset === 0 || loading}
@@ -154,6 +156,7 @@ export default function ConversionHistoryPage() {
                 ← Previous
               </button>
               <button
+                type="button"
                 className="btn btn-secondary"
                 onClick={() => setOffset(offset + PAGE_SIZE)}
                 disabled={loading || offset + PAGE_SIZE >= total}

--- a/frontend/src/pages/DiffPage.tsx
+++ b/frontend/src/pages/DiffPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "@umijs/max";
 import { useTranslation } from "react-i18next";
-import { ArrowRight, RotateCcw, FileDown, Loader2, AlertTriangle, Eye } from "lucide-react";
+import { ArrowRight, RotateCcw, FileDown, AlertTriangle, Eye } from "lucide-react";
 import ConversionVisualBoard from "../components/diff/ConversionVisualBoard";
 import SideBySideGraph from "../components/diff/SideBySideGraph";
 import NodeDetailDrawer from "../components/diff/NodeDetailDrawer";
@@ -173,13 +173,17 @@ export default function DiffPage() {
       {/* Action Bar */}
       <div style={{ marginTop: 32, display: "flex", gap: 12 }}>
         <button
+          type="button"
           className="btn btn-primary"
           onClick={() => navigate(`/migrate/result/${conversionId}`)}
         >
           <ArrowRight size={15} />
           {t("diff.continueToExport")}
         </button>
-        <button className="btn btn-secondary" onClick={() => {
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={() => {
           const report = activeReport;
           const lines = [
             `# Conversion Report: ${report.workflow_name}`,
@@ -212,11 +216,12 @@ export default function DiffPage() {
           a.download = `conversion-report-${conversionId}.md`;
           a.click();
           URL.revokeObjectURL(url);
-        }}>
+          }}
+        >
           <FileDown size={15} />
           {t("diff.downloadReport")}
         </button>
-        <button className="btn btn-ghost" onClick={() => navigate("/migrate")}>
+        <button type="button" className="btn btn-ghost" onClick={() => navigate("/migrate")}>
           <RotateCcw size={15} />
           {t("diff.startOver")}
         </button>

--- a/frontend/src/pages/MigratePage.tsx
+++ b/frontend/src/pages/MigratePage.tsx
@@ -111,6 +111,7 @@ export default function MigratePage() {
       <div className="tab-bar" style={{ marginBottom: 24 }}>
         {tabs.map((tabItem) => (
           <button
+            type="button"
             key={tabItem.key}
             className={`tab-btn ${tab === tabItem.key ? "tab-btn--active" : ""}`}
             onClick={() => setTab(tabItem.key)}

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "@umijs/max";
+import { useParams } from "@umijs/max";
 import { useTranslation } from "react-i18next";
-import { AlertTriangle, Rocket, Loader2 } from "lucide-react";
+import { AlertTriangle, Rocket } from "lucide-react";
 import PageShell from "../components/common/PageShell";
 import EmptyState from "../components/common/EmptyState";
 import Skeleton from "../components/common/Skeleton";
@@ -14,7 +14,6 @@ import { getConversion } from "../api/conversion";
 
 export default function ResultPage() {
   const { conversionId } = useParams();
-  const navigate = useNavigate();
   const { t } = useTranslation();
   const {
     conversionId: storedConversionId,

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -142,6 +142,7 @@ export default function SettingsPage() {
             </div>
             <div>
               <button
+                type="button"
                 className="btn btn-primary"
                 onClick={handleTestCoze}
                 disabled={testing === "coze" || !cozeTokenInput}
@@ -192,6 +193,7 @@ export default function SettingsPage() {
             </div>
             <div>
               <button
+                type="button"
                 className="btn btn-primary"
                 onClick={handleTestDify}
                 disabled={testing === "dify" || !difyBaseInput || !difyKeyInput}
@@ -229,6 +231,7 @@ export default function SettingsPage() {
             </span>
             <div style={{ display: "flex", gap: 8 }}>
               <button
+                type="button"
                 className={`btn ${i18n.language === "en" ? "btn-primary" : "btn-ghost"}`}
                 onClick={() => handleLanguageChange("en")}
                 style={{ padding: "6px 14px", fontSize: "0.82rem" }}
@@ -236,6 +239,7 @@ export default function SettingsPage() {
                 {t("settings.english")}
               </button>
               <button
+                type="button"
                 className={`btn ${i18n.language === "zh" ? "btn-primary" : "btn-ghost"}`}
                 onClick={() => handleLanguageChange("zh")}
                 style={{ padding: "6px 14px", fontSize: "0.82rem" }}

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -111,6 +111,7 @@ export default function UploadPage() {
       <div className="tab-bar" style={{ marginBottom: 24 }}>
         {tabs.map((t) => (
           <button
+            type="button"
             key={t.key}
             className={`tab-btn ${tab === t.key ? "tab-btn--active" : ""}`}
             onClick={() => setTab(t.key)}


### PR DESCRIPTION
## Summary
- fix the straightforward lint issues across the lightweight page flows
- expand the frontend lint script to cover those page files
- leave the larger `MigrationWorkbenchPage`, `SyncHistoryPage`, and `SyncPage` refactors for follow-up slices

Closes #103

## Validation
- cd frontend && npm run lint
- cd frontend && npm run test
- cd frontend && npx tsc --noEmit
- cd frontend && npm run build
- cd frontend && npx max lint --eslint-only "src/pages/**/*.{ts,tsx}"